### PR TITLE
ci: add udeps and msrv checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,17 @@ jobs:
           rustup component add clippy
           cargo clippy --workspace --all-targets -- -D warnings
 
+      - name: Unused dependencies (deny)
+        run: |
+          rustup toolchain install nightly --profile minimal --no-self-update
+          cargo +nightly install cargo-udeps --locked
+          cargo +nightly udeps --workspace --all-targets
+
+      - name: MSRV (verify)
+        run: |
+          cargo install cargo-msrv --locked
+          cargo msrv verify
+
       - name: Package artifact (Windows)
         if: runner.os == 'Windows'
         shell: pwsh

--- a/docs/developer/ci.md
+++ b/docs/developer/ci.md
@@ -27,3 +27,15 @@ scripts/test.ps1
 scripts/package.ps1
 ```
 
+Additional checks
+```bash
+# Unused dependencies
+rustup toolchain install nightly --profile minimal
+cargo +nightly install cargo-udeps --locked
+cargo +nightly udeps --workspace --all-targets
+
+# Verify MSRV
+cargo install cargo-msrv --locked
+cargo msrv verify
+```
+


### PR DESCRIPTION
## Summary
- run cargo-udeps in CI to fail on unused dependencies
- verify MSRV in CI
- document how to run dependency and MSRV checks locally

## Testing
- `cargo test --workspace --locked` *(fails: linking with `cc` failed)*
- `cargo +nightly udeps --workspace --all-targets` *(fails: no such command `udeps`)*
- `cargo msrv --version` *(fails: no such command `msrv`)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf9d0fa408330b249689b3fba8e11