### PR TITLE
Add WASM plugin scaffold and loader

### DIFF
--- a/crates/arw-core/Cargo.toml
+++ b/crates/arw-core/Cargo.toml
@@ -15,3 +15,11 @@ regex = { workspace = true }
 
 
 inventory = { workspace = true }
+
+# Optional runtime for loading WASM plug‑ins
+wasmtime = { version = "36.0.2", optional = true, features = ["component-model"] }
+wit-bindgen = { version = "0.45.1", optional = true }
+
+[features]
+default = []
+wasm = ["wasmtime", "wit-bindgen"]

--- a/crates/arw-core/src/lib.rs
+++ b/crates/arw-core/src/lib.rs
@@ -2,6 +2,9 @@ use serde::Serialize;
 use serde_json::{json, Value};
 use std::collections::HashSet;
 
+#[cfg(feature = "wasm")]
+pub mod wasm;
+
 /// Public metadata describing a tool that can be registered into the runtime.
 #[derive(Clone, Serialize)]
 pub struct ToolInfo {
@@ -116,36 +119,76 @@ pub fn hello_core() -> &'static str {
 /// Compute effective paths and portability flags (env-based; cross‑platform).
 pub fn load_effective_paths() -> serde_json::Value {
     // Load defaults from config file if present, then overlay env vars
-    let cfg_path = std::env::var("ARW_CONFIG").ok().unwrap_or_else(|| "configs/default.toml".to_string());
-    let cfg = std::fs::read_to_string(&cfg_path).ok().and_then(|s| toml::from_str::<toml::Value>(&s).ok());
+    let cfg_path = std::env::var("ARW_CONFIG")
+        .ok()
+        .unwrap_or_else(|| "configs/default.toml".to_string());
+    let cfg = std::fs::read_to_string(&cfg_path)
+        .ok()
+        .and_then(|s| toml::from_str::<toml::Value>(&s).ok());
 
     let portable = std::env::var("ARW_PORTABLE")
         .ok()
         .and_then(|v| v.parse::<bool>().ok())
-        .or_else(|| cfg.as_ref().and_then(|v| v.get("runtime").and_then(|r| r.get("portable")).and_then(|b| b.as_bool())))
+        .or_else(|| {
+            cfg.as_ref().and_then(|v| {
+                v.get("runtime")
+                    .and_then(|r| r.get("portable"))
+                    .and_then(|b| b.as_bool())
+            })
+        })
         .unwrap_or(false);
 
-    let home_like = std::env::var("LOCALAPPDATA").or_else(|_| std::env::var("HOME")).unwrap_or_else(|_| ".".into());
+    let home_like = std::env::var("LOCALAPPDATA")
+        .or_else(|_| std::env::var("HOME"))
+        .unwrap_or_else(|_| ".".into());
     let norm = |s: String| s.replace('\\', "/");
     let expand = |mut s: String| {
         // Very small %VAR% and $VAR expansion for portability
         for (k, v) in std::env::vars() {
             let p1 = format!("%{}%", k);
             let p2 = format!("${}", k);
-            if s.contains(&p1) { s = s.replace(&p1, &v); }
-            if s.contains(&p2) { s = s.replace(&p2, &v); }
+            if s.contains(&p1) {
+                s = s.replace(&p1, &v);
+            }
+            if s.contains(&p2) {
+                s = s.replace(&p2, &v);
+            }
         }
         norm(s)
     };
 
-    let state_dir = std::env::var("ARW_STATE_DIR").ok()
-        .or_else(|| cfg.as_ref().and_then(|v| v.get("runtime").and_then(|r| r.get("state_dir")).and_then(|s| s.as_str()).map(|s| s.to_string())))
+    let state_dir = std::env::var("ARW_STATE_DIR")
+        .ok()
+        .or_else(|| {
+            cfg.as_ref().and_then(|v| {
+                v.get("runtime")
+                    .and_then(|r| r.get("state_dir"))
+                    .and_then(|s| s.as_str())
+                    .map(|s| s.to_string())
+            })
+        })
         .unwrap_or_else(|| format!("{}/arw", home_like.clone()));
-    let cache_dir = std::env::var("ARW_CACHE_DIR").ok()
-        .or_else(|| cfg.as_ref().and_then(|v| v.get("runtime").and_then(|r| r.get("cache_dir")).and_then(|s| s.as_str()).map(|s| s.to_string())))
+    let cache_dir = std::env::var("ARW_CACHE_DIR")
+        .ok()
+        .or_else(|| {
+            cfg.as_ref().and_then(|v| {
+                v.get("runtime")
+                    .and_then(|r| r.get("cache_dir"))
+                    .and_then(|s| s.as_str())
+                    .map(|s| s.to_string())
+            })
+        })
         .unwrap_or_else(|| format!("{}/arw/cache", home_like.clone()));
-    let logs_dir = std::env::var("ARW_LOGS_DIR").ok()
-        .or_else(|| cfg.as_ref().and_then(|v| v.get("runtime").and_then(|r| r.get("logs_dir")).and_then(|s| s.as_str()).map(|s| s.to_string())))
+    let logs_dir = std::env::var("ARW_LOGS_DIR")
+        .ok()
+        .or_else(|| {
+            cfg.as_ref().and_then(|v| {
+                v.get("runtime")
+                    .and_then(|r| r.get("logs_dir"))
+                    .and_then(|s| s.as_str())
+                    .map(|s| s.to_string())
+            })
+        })
         .unwrap_or_else(|| format!("{}/arw/logs", home_like));
 
     serde_json::json!({

--- a/crates/arw-core/src/wasm.rs
+++ b/crates/arw-core/src/wasm.rs
@@ -1,0 +1,44 @@
+//! Helpers for loading WASM plug‑ins implementing the `tool` ABI.
+#![cfg(feature = "wasm")]
+
+use anyhow::Result;
+use wasmtime::component::{bindgen, Component, Linker};
+use wasmtime::{Engine, Store};
+// Re-export the Engine type for downstream macros/helpers
+pub use wasmtime::Engine;
+
+// Generate bindings from the simple tool ABI defined in `wit/tool.wit`.
+bindgen!({ path: "./wit", world: "plugin" });
+
+/// Runtime wrapper around a compiled WASM plug‑in implementing the `tool` interface.
+pub struct WasmTool {
+    instance: Plugin,
+    store: Store<()>,
+    info: ToolInfo,
+}
+
+impl WasmTool {
+    /// Load a new plug‑in from raw bytes.
+    pub fn from_bytes(engine: &Engine, bytes: &[u8]) -> Result<Self> {
+        let component = Component::from_binary(engine, bytes)?;
+        let mut linker = Linker::new(engine);
+        let mut store = Store::new(engine, ());
+        let instance = Plugin::new(&mut store, &component, &linker)?;
+        let info = instance.call_register(&mut store)?;
+        Ok(Self {
+            instance,
+            store,
+            info,
+        })
+    }
+
+    /// Metadata exposed by the plug‑in.
+    pub fn info(&self) -> &ToolInfo {
+        &self.info
+    }
+
+    /// Invoke the plug‑in with a JSON string.
+    pub fn invoke(&mut self, input: &str) -> Result<String> {
+        self.instance.call_invoke(&mut self.store, input)
+    }
+}

--- a/crates/arw-core/wit/tool.wit
+++ b/crates/arw-core/wit/tool.wit
@@ -1,0 +1,19 @@
+package arw:tool
+
+record tool-info {
+  id: string,
+  version: string,
+  summary: string,
+  stability: string,
+}
+
+interface tool {
+  /// Return metadata describing the tool
+  register: func() -> tool-info
+  /// Invoke the tool with a JSON string and return a JSON result
+  invoke: func(input: string) -> string
+}
+
+world plugin {
+  export tool
+}

--- a/crates/arw-macros/src/lib.rs
+++ b/crates/arw-macros/src/lib.rs
@@ -105,10 +105,19 @@ pub fn arw_tool(attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut preamble = proc_macro2::TokenStream::new();
     if id.as_deref().is_none() || id.as_deref().unwrap().trim().is_empty() {
         preamble.extend(quote! { compile_error!("#[arw_tool] requires a non-empty id=\"...\""); });
-    } else if let Some(ref s) = id { if !s.contains('.') || s.contains(' ') { preamble.extend(quote! { compile_error!("arw_tool id should include a namespace (e.g., ns.name) and no spaces"); }); } }
+    } else if let Some(ref s) = id {
+        if !s.contains('.') || s.contains(' ') {
+            preamble.extend(quote! { compile_error!("arw_tool id should include a namespace (e.g., ns.name) and no spaces"); });
+        }
+    }
     if version.as_deref().is_none() || version.as_deref().unwrap().trim().is_empty() {
-        preamble.extend(quote! { compile_error!("#[arw_tool] requires a semver version=\"x.y.z\""); });
-    } else if let Some(ref v) = version { if !v.chars().all(|c| c.is_ascii_digit() || c=='.') || v.split('.').count() < 3 { preamble.extend(quote! { compile_error!("arw_tool version should look like x.y.z"); }); } }
+        preamble
+            .extend(quote! { compile_error!("#[arw_tool] requires a semver version=\"x.y.z\""); });
+    } else if let Some(ref v) = version {
+        if !v.chars().all(|c| c.is_ascii_digit() || c == '.') || v.split('.').count() < 3 {
+            preamble.extend(quote! { compile_error!("arw_tool version should look like x.y.z"); });
+        }
+    }
 
     let gen = quote! {
         #preamble
@@ -123,5 +132,19 @@ pub fn arw_tool(attr: TokenStream, item: TokenStream) -> TokenStream {
             }
         }
     };
+    gen.into()
+}
+
+/// Include a WASM plug‑in at compile time and instantiate it using `arw-core`'s
+/// runtime helpers. Usage: `load_wasm_tool!("path/to/plugin.wasm")`.
+#[proc_macro]
+pub fn load_wasm_tool(input: TokenStream) -> TokenStream {
+    let path = parse_macro_input!(input as LitStr);
+    let gen = quote! {{
+        use arw_core::wasm::{Engine, WasmTool};
+        static WASM_BYTES: &[u8] = include_bytes!(#path);
+        let engine = Engine::default();
+        WasmTool::from_bytes(&engine, WASM_BYTES).expect("invalid WASM module")
+    }};
     gen.into()
 }

--- a/crates/example-wasm-plugin/Cargo.toml
+++ b/crates/example-wasm-plugin/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "example-wasm-plugin"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { version = "0.45.1", default-features = false, features = ["realloc"] }
+
+[workspace]

--- a/crates/example-wasm-plugin/src/lib.rs
+++ b/crates/example-wasm-plugin/src/lib.rs
@@ -1,0 +1,25 @@
+// Example WASM plug‑in implementing the `arw:tool` ABI defined in
+// `crates/arw-core/wit/tool.wit`.
+
+wit_bindgen::generate!("../arw-core/wit");
+
+use exports::arw::tool::ToolInfo;
+
+struct Echo;
+
+impl exports::arw::tool::Guest for Echo {
+    fn register() -> ToolInfo {
+        ToolInfo {
+            id: "wasm.echo".to_string(),
+            version: "1.0.0".to_string(),
+            summary: "Echo input back via WASM".to_string(),
+            stability: "experimental".to_string(),
+        }
+    }
+
+    fn invoke(input: String) -> String {
+        format!("echo: {}", input)
+    }
+}
+
+export!(Echo);


### PR DESCRIPTION
## Summary
- add optional wasmtime/wit-bindgen runtime in `arw-core`
- expose WASM plug-in ABI and loader helpers
- provide example `wasm.echo` plug-in and macro to include it

## Testing
- `cargo test -p arw-core -p arw-macros`
- ⚠️ `cargo check --manifest-path crates/example-wasm-plugin/Cargo.toml --target wasm32-unknown-unknown` *(missing `wasm32-unknown-unknown` target)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf9d460288330bb27dae9fa31afcf