### PR TITLE
feat(arw-svc): add OpenAPI spec generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,11 @@ jobs:
       - name: Test
         run: cargo test --workspace --locked
 
+      - name: Verify OpenAPI spec
+        run: |
+          OPENAPI_OUT=docs/api/openapi.yaml cargo run --locked -p arw-svc --quiet
+          git diff --exit-code docs/api/openapi.yaml
+
       - name: Rustfmt (check)
         run: |
           rustup component add rustfmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,7 @@ dependencies = [
  "tower 0.4.13",
  "tower-http 0.5.2",
  "tracing",
+ "utoipa",
  "uuid",
 ]
 
@@ -1456,6 +1457,7 @@ checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
+ "serde",
 ]
 
 [[package]]
@@ -2437,6 +2439,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap 2.11.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3056,6 +3071,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3100,6 +3121,31 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utoipa"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+dependencies = [
+ "indexmap 2.11.0",
+ "serde",
+ "serde_json",
+ "serde_norway",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ once_cell = "1"
 syn = { version = "2", features = ["full"] }
 quote = "1"
 proc-macro2 = "1"
+utoipa = { version = "5", features = ["axum_extras","yaml"] }
 
 [profile.dev]
 opt-level = 1

--- a/apps/arw-svc/Cargo.toml
+++ b/apps/arw-svc/Cargo.toml
@@ -20,6 +20,7 @@ tower-http = { version = "0.5", features = ["trace","compression-br","compressio
 # uuid is available workspace-wide if needed later for ids
 uuid = { workspace = true }
 chrono = { workspace = true }
+utoipa = { workspace = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros","rt-multi-thread"] }

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,0 +1,89 @@
+openapi: 3.1.0
+info:
+  title: arw-svc
+  description: ''
+  license:
+    name: ''
+  version: 0.1.0
+paths:
+  /emit/test:
+    get:
+      tags: []
+      operationId: emit_test
+      responses:
+        '200':
+          description: Emit test event
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OkResponse'
+  /events:
+    get:
+      tags: []
+      operationId: events
+      responses:
+        '200':
+          description: SSE event stream
+  /healthz:
+    get:
+      tags: []
+      operationId: healthz
+      responses:
+        '200':
+          description: Service health
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OkResponse'
+  /introspect/schemas/{id}:
+    get:
+      tags: []
+      operationId: introspect_schema
+      parameters:
+      - name: id
+        in: path
+        description: Tool id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Schema JSON
+        '404':
+          description: Unknown tool id
+  /introspect/tools:
+    get:
+      tags: []
+      operationId: introspect_tools
+      responses:
+        '200':
+          description: List available tools
+  /probe:
+    get:
+      tags: []
+      operationId: probe
+      responses:
+        '200':
+          description: Returns effective memory paths
+  /shutdown:
+    get:
+      tags: []
+      operationId: shutdown
+      responses:
+        '200':
+          description: Shutdown service
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OkResponse'
+components:
+  schemas:
+    OkResponse:
+      type: object
+      required:
+      - ok
+      properties:
+        ok:
+          type: boolean
+tags:
+- name: arw-svc


### PR DESCRIPTION
## Summary
- integrate utoipa in `arw-svc` and annotate routes
- generate `docs/api/openapi.yaml`
- CI checks that schema is up to date

## Testing
- `cargo test -p arw-svc --locked`
- `cargo test --workspace --locked` *(fails: gdk-3.0 required by gdk-sys not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf9d6fa5c83308df05b11b287d856