### PR TITLE
feat: add uninstall script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Quickstart
   - Build: `scripts/build.ps1` (Windows) or `scripts/build.sh` (Linux/macOS)
   - Test:  `scripts/test.ps1` or `scripts/test.sh`
   - Package: `scripts/package.ps1` or `scripts/package.sh` (creates `dist/` zip)
+  - Uninstall: `scripts/uninstall.ps1` or `scripts/uninstall.sh` (removes build artifacts and MkDocs packages installed by setup)
 
 Docs
 - Browse the user guide and developer docs with MkDocs.

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -15,6 +15,9 @@ function Pause($m){ if(-not $Yes){ Read-Host $m | Out-Null } }
 Title 'Prerequisites'
 $root = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
 Push-Location $root
+# Record install actions for uninstall.ps1
+$installLog = Join-Path $root '.install.log'
+"# Install log - $(Get-Date)" | Out-File $installLog -Encoding UTF8
 if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
   Warn 'Rust `cargo` not found.'
   Write-Host 'Install Rust via rustup:' -ForegroundColor Yellow
@@ -32,6 +35,11 @@ if (-not $py) {
       Info 'MkDocs not found. Attempting to install via pip...'
       try { & $py.Path -m pip install --upgrade pip | Out-Null } catch { Warn 'pip upgrade failed (continuing).'}
       try { & $py.Path -m pip install mkdocs mkdocs-material mkdocs-git-revision-date-localized-plugin } catch { Warn 'pip install for mkdocs failed. Docs site will be skipped.' }
+      if (Get-Command mkdocs -ErrorAction SilentlyContinue) {
+        foreach($pkg in 'mkdocs','mkdocs-material','mkdocs-git-revision-date-localized-plugin') { Add-Content $installLog "PIP $pkg" }
+      } else {
+        Warn 'MkDocs install failed. Docs site will be skipped.'
+      }
     }
   }
 }
@@ -61,6 +69,8 @@ try {
   Warn "package.ps1 blocked by execution policy; retrying via child PowerShell with Bypass"
   & powershell -ExecutionPolicy Bypass -File (Join-Path $PSScriptRoot 'package.ps1') -NoBuild
 }
+'DIR target','DIR dist' | ForEach-Object { Add-Content $installLog $_ }
+if (Test-Path (Join-Path $root 'site')) { Add-Content $installLog 'DIR site' }
 
 Pop-Location
 Info 'Done. See dist/ for portable bundle.'

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$DIR/.." && pwd)"
 
+# Track what this setup installs so uninstall.sh can undo it later
+INSTALL_LOG="$ROOT/.install.log"
+echo "# Install log - $(date)" > "$INSTALL_LOG"
+
 yes_flag=0
 no_docs=0
 run_tests=0
@@ -35,7 +39,12 @@ if [[ $no_docs -eq 0 && $mkdocs_ok -eq 0 ]]; then
     info "Installing MkDocs via pip"
     python3 -m pip install --upgrade pip || true
     python3 -m pip install mkdocs mkdocs-material mkdocs-git-revision-date-localized-plugin || true
-    command -v mkdocs >/dev/null 2>&1 && mkdocs_ok=1 || warn "MkDocs install failed; docs site will be skipped"
+    if command -v mkdocs >/dev/null 2>&1; then
+      mkdocs_ok=1
+      printf 'PIP %s\n' mkdocs mkdocs-material mkdocs-git-revision-date-localized-plugin >> "$INSTALL_LOG"
+    else
+      warn "MkDocs install failed; docs site will be skipped"
+    fi
   else
     warn "python3 not found; skipping docs site build"
   fi
@@ -65,4 +74,6 @@ fi
 
 title "Package portable bundle"
 bash "$DIR/package.sh" --no-build
+printf '%s\n' 'DIR target' 'DIR dist' >> "$INSTALL_LOG"
+[[ -d "$ROOT/site" ]] && echo 'DIR site' >> "$INSTALL_LOG"
 info "Done. See dist/ for portable bundle."

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -1,0 +1,50 @@
+#!powershell
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$root = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$log = Join-Path $root '.install.log'
+if (-not (Test-Path $log)) {
+  Write-Host '[uninstall] No install log found; nothing to do.'
+  exit 0
+}
+$removed = @()
+$left = @()
+$py = (Get-Command python -ErrorAction SilentlyContinue) ?? (Get-Command python3 -ErrorAction SilentlyContinue)
+Get-Content $log | ForEach-Object {
+  if ($_ -match '^(#|\s*$)') { return }
+  $parts = $_.Split(' ',2)
+  $type = $parts[0]
+  $item = $parts[1]
+  switch ($type) {
+    'DIR' {
+      $path = Join-Path $root $item
+      if (Test-Path $path) {
+        Remove-Item -Recurse -Force $path
+        $removed += $item
+      } else {
+        $left += "$item (missing)"
+      }
+    }
+    'PIP' {
+      if ($py) {
+        try {
+          & $py.Path -m pip uninstall -y $item | Out-Null
+          $removed += "pip package $item"
+        } catch {
+          $left += "pip package $item"
+        }
+      } else {
+        $left += "pip package $item (python not found)"
+      }
+    }
+  }
+}
+Remove-Item -Force $log
+Write-Host '[uninstall] Removed:'
+foreach ($r in $removed) { Write-Host "  - $r" }
+if ($left.Count -gt 0) {
+  Write-Host '[uninstall] Left on system:'
+  foreach ($k in $left) { Write-Host "  - $k" }
+}
+Write-Host '[uninstall] Done.'

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$DIR/.." && pwd)"
+LOG="$ROOT/.install.log"
+
+if [[ ! -f "$LOG" ]]; then
+  echo "[uninstall] No install log found; nothing to do."
+  exit 0
+fi
+
+removed=()
+left=()
+pycmd="python3"
+if ! command -v python3 >/dev/null 2>&1 && command -v python >/dev/null 2>&1; then
+  pycmd="python"
+fi
+
+while read -r type item; do
+  [[ -z "$type" || "$type" == \#* ]] && continue
+  case "$type" in
+    DIR)
+      path="$ROOT/$item"
+      if [[ -e "$path" ]]; then
+        rm -rf "$path"
+        removed+=("$item")
+      else
+        left+=("$item (missing)")
+      fi
+      ;;
+    PIP)
+      if command -v "$pycmd" >/dev/null 2>&1; then
+        if "$pycmd" -m pip uninstall -y "$item" >/dev/null 2>&1; then
+          removed+=("pip package $item")
+        else
+          left+=("pip package $item")
+        fi
+      else
+        left+=("pip package $item (python not found)")
+      fi
+      ;;
+  esac
+done < "$LOG"
+
+rm -f "$LOG"
+
+echo "[uninstall] Removed:"
+for r in "${removed[@]}"; do
+  echo "  - $r"
+done
+if [[ ${#left[@]} -gt 0 ]]; then
+  echo "[uninstall] Left on system:"
+  for k in "${left[@]}"; do
+    echo "  - $k"
+  done
+fi
+
+echo "[uninstall] Done."


### PR DESCRIPTION
## Summary
- track install actions in setup scripts
- add cross-platform uninstall scripts to remove recorded items
- document uninstall helper in README

## Testing
- `bash scripts/test.sh` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bed6c5dda483308a324322e6f0d4fc