### PR TITLE
docs: add complexity collapse initiative

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -12,6 +12,17 @@ Status: unless noted, items are todo. Items that have task IDs link to the track
 
 ## Now (Weeks)
 
+Complexity Collapse (Cross-cutting)
+- One service API surface (`/state`, `/events`, `/actions`) with no side channels
+- Single SQLite journal with content-addressed blobs; derive read-models and caches
+- Job model & scheduler as the only execution path; unify local and remote runners
+- Patch engine for all writes with diff preview and rollback
+- Documented event taxonomy; views/read-models subscribe to the event stream
+- Flows as DAG data executed by a single flow-runner; tools are schema-defined nodes
+- Unified retrieval pipeline and memory abstraction (vector/graph/kv/doc) with shared CRUD/stats and index hygiene
+- Capability/lease system with node-local egress proxy; remove per-tool allowlists
+- UI: shared right-sidecar, schema-generated forms, and global command palette
+
 Never‑Out‑Of‑Context (High Priority)
 - [t-250912143001-0001] Context Working Set doc + mkdocs nav — done (this change)
 - [t-250912143005-0002] Context API: allow slot budgets and return stable pointers (IDs) for all included items — todo

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -43,6 +43,12 @@ Roadmap highlights themes and timelines; Backlog tracks actionable items.
 Scope: Lightweight, near‑live suggestions with guardrails.
 See Backlog → Now → Feedback Engine for concrete work items.
 
+## Complexity Collapse Initiative
+- Collapse surfaces to one API (`/state`, `/events`, `/actions`), one SQLite journal + content-addressed blobs, one job scheduler, one plugin ABI, and a shared UI sidecar/form builder.
+- Schema-first patches for Project/AgentProfile/Policy/etc. with a documented event taxonomy; flows and errors modeled as data.
+- Unified engines: retrieval pipeline, memory abstraction, runtime/cluster matrix, and capability/lease security.
+- Goal: keep the kernel tiny; push features into declarative packs and reusable executors.
+
 ## Mid‑Term (1–2 Months)
 - UI app to manage various project types.
 - WASI plugin sandbox: capability‑based tools with explicit permissions.


### PR DESCRIPTION
## Summary
- outline Complexity Collapse initiative in roadmap and backlog
- document concrete tasks to unify API, storage, scheduler, and UI surfaces

## Testing
- `bash scripts/docs_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c4289f10888330a86ee03bac57bca7