### PR TITLE
ci: fix Linux deps for tauri + CodeQL path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install system deps (Linux GUI)
+        run: |
+          sudo apt-get update
+          # GTK/WebKitGTK and related deps for tauri/wry (Linux)
+          sudo apt-get install -y \
+            pkg-config \
+            build-essential \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+          # WebKitGTK API version varies by Ubuntu image; try 4.1 then 4.0
+          sudo apt-get install -y libwebkit2gtk-4.1-dev || \
+          sudo apt-get install -y libwebkit2gtk-4.0-dev
       - uses: dtolnay/rust-toolchain@stable
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,13 +19,27 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install system deps (Linux GUI)
+        run: |
+          sudo apt-get update
+          # GTK/WebKitGTK and related deps for tauri/wry (Linux)
+          sudo apt-get install -y \
+            pkg-config \
+            build-essential \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+          # WebKitGTK API version varies by Ubuntu image; try 4.1 then 4.0
+          sudo apt-get install -y libwebkit2gtk-4.1-dev || \
+          sudo apt-get install -y libwebkit2gtk-4.0-dev
+      - name: Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
           languages: rust
       - name: Build (workspace)
         run: |
-          cd Agent_Hub
           cargo build --workspace --locked
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
- Install GTK/WebKitGTK and related packages for Tauri/Wry builds on ubuntu-latest\n- Add Rust toolchain to CodeQL workflow\n- Build workspace from repo root (remove stray 'cd Agent_Hub')\n\nThis should fix the failing 'rust' and 'Analyze (CodeQL)' workflows on main.