### PR TITLE
ci(labels): fix label sync workflow

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Sync labels
         uses: crazy-max/ghaction-github-labeler@v5
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          yaml-file: .github/labels.yml
           skip-delete: true
-          config-file: .github/labels.yml
-


### PR DESCRIPTION
- Use correct inputs for crazy-max/ghaction-github-labeler@v5 (yaml-file, github-token)\n- Keep skip-delete enabled\n\nShould resolve the labels workflow failing without logs.