### PR TITLE
ci(labels): ensure workflow triggers run

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -5,6 +5,11 @@ on:
     branches: [ main, master ]
     paths:
       - .github/labels.yml
+      - .github/workflows/labels.yml
+  pull_request:
+    paths:
+      - .github/labels.yml
+      - .github/workflows/labels.yml
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
- Run on changes to both .github/labels.yml and the workflow file\n- Add pull_request trigger for visibility in PRs\n\nThis should avoid empty/no-job runs and make manual + push triggers reliable.