### PR TITLE
ci(labels): add dry-run on PRs

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -27,3 +27,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           yaml-file: .github/labels.yml
           skip-delete: true
+          dry-run: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
Run label sync in dry-run mode on PRs to show changes without editing labels.\nAlso validates the workflow actually schedules jobs.