### PR TITLE
Simplify long-term roadmap scope

### DIFF
--- a/archive/CLUSTERING.md
+++ b/archive/CLUSTERING.md
@@ -10,6 +10,8 @@ Type: Explanation
 
 See also: [Roadmap](ROADMAP.md)
 
+> **Note (2025-09):** Earlier drafts explored Bitcoin bridges for connectors. The active roadmap drops that scope to keep clustering focused on local-first coordination.
+
 - Default behavior remains single-process using a local in-memory queue and event bus.
 - Medium-depth scale-out uses a pluggable Queue and Bus abstraction with NATS JetStream as the recommended backend.
 
@@ -21,12 +23,6 @@ Egress posture (planned)
 - Simple operational model, low latency, at-least-once with durable consumer groups.
 - Built-in discovery and clustering; easy to add nodes (“connect a second”).
 - Good bridgeability to edge environments and compatible with future p2p overlays.
-- Can co-exist with Bitcoin ecosystem tooling; we can bridge ZMQ publishers from `bitcoind` into NATS subjects for event-driven workflows.
-
-## Bitcoin/Blockchain Alignment
-- Identity: leverage secp256k1 keys (Lightning/Bitcoin-style) for mTLS/Noise handshakes between cores and connectors.
-- Event ingress: optional ZeroMQ adapter to consume `bitcoind` notifications, republish into Bus/Queue.
-- Provenance: sign connector binaries/plugins with Sigstore; attestments can be anchored or mirrored alongside Bitcoin timestamping services if desired.
 
 ## MVP in This Repo
 - `arw-core::orchestrator`: Task model, LocalQueue with leases, and Orchestrator façade.
@@ -48,4 +44,3 @@ queue = "local" # or "nats" (feature: arw-core/nats)
 - Implement JetStream durable queues with consumer groups and ack/nack/delay semantics.
 - Add outbound NATS relay (loop-safe) when needed for cross-node fan-out.
 - Define connector control-plane (gRPC/QUIC) for Hello/Heartbeat/Assignment.
-- Optional ZMQ bridge for Bitcoin Core notifications -> Bus/Queue.

--- a/archive/HIERARCHY.md
+++ b/archive/HIERARCHY.md
@@ -10,6 +10,8 @@ Type: Explanation
 
 See also: [Roadmap](ROADMAP.md)
 
+> **Note (2025-09):** Blockchain tie-ins were explored in earlier drafts. We now focus hierarchy work purely on core-to-core coordination.
+
 ## Goals
 - Allow cores to negotiate roles and relationships dynamically (root/regional/edge/connector/observer).
 - Keep the hot data plane decentralized (queue/bus) while the control plane is light.
@@ -46,6 +48,3 @@ See also: [Roadmap](ROADMAP.md)
 - Leader/lease: optional OpenRaft/etcd only for rare global operations; keep hot path queue-driven.
 - Policy: OPA/Cedar rules gate role changes, parent selection, shard assignments.
 
-## Bitcoin Alignment
-- Identity: use secp256k1-derived identities for mutual auth (SPIFFE/SPIRE or Noise).
-- Event ingress: ZeroMQ bridge from bitcoind -> NATS subjects; region roots filter/aggregate.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -101,18 +101,13 @@ See Backlog → Now → Feedback Engine for concrete work items.
 - Minimal broker (optional): tiny relay/directory for NAT‑tricky cases; stateless/replaceable.
 
 ## Long‑Term (3–6 Months)
-- Community training interface/simulation:
-  - Online opt‑in interface; privacy‑preserving local preprocessing.
-  - Metrics for “interaction quality” (clarity, helpfulness, faithfulness, novelty).
-  - Value alignment via debate/consensus rounds; transparent rationale graphs.
-  - Weighted participation (democratic/liquid/interest‑group based).
-- Governance & decision systems:
-  - Composable priorities; dynamic hierarchies; fairness and safety constraints.
-  - Argument mapping, counterfactual sandboxing, and policy proofs.
+- Ledger‑driven settlement tooling:
+  - Contribution meter and revenue ledger mature into auditable exports for collaborators.
+  - Opt‑in policy templates help teams review disputes locally without a separate governance simulator.
 - Research‑grade local stack:
   - On‑device accel (CPU/GPU/NPU), quantization, LoRA fine‑tuning, model manifests.
   - Artifact signing/verification, SBOMs, and dependency audits.
-  - Signed policy capsules with Sigstore; optional Bitcoin anchoring for timestamping (opt‑in; renegotiation on restart remains default).
+  - Signed policy capsules with Sigstore; rely on RPU trust store + local timestamping (renegotiation on restart remains default).
 
 ## Guiding Principles
 - Local‑first, open, privacy‑respecting, and comprehensible.


### PR DESCRIPTION
## Summary
- remove the community governance/training blocks from the long-term roadmap and focus on ledger-driven settlement tooling instead
- drop the optional Bitcoin anchoring reference in the roadmap and clarify the archival clustering/hierarchy notes to state that blockchain alignment is no longer planned

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c9e2efdff88330add223964da267e4