### PR TITLE
Add scope badges to roadmap and backlog

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -14,262 +14,262 @@ Status: unless noted, items are todo. Items that have task IDs link to the track
 ## Now (Weeks)
 
 Complexity Collapse (Cross-cutting)
-- One service API surface (`/state`, `/events`, `/actions`) with no side channels
-- Single SQLite journal with content-addressed blobs; derive read-models and caches
-- Job model & scheduler as the only execution path; unify local and remote runners
-- Patch engine for all writes with diff preview and rollback
-- Documented event taxonomy; views/read-models subscribe to the event stream
-- Flows as DAG data executed by a single flow-runner; tools are schema-defined nodes
-- Unified retrieval pipeline and memory abstraction (vector/graph/kv/doc) with shared CRUD/stats and index hygiene
-- Capability/lease system with node-local egress proxy; remove per-tool allowlists
-- UI: shared right-sidecar, schema-generated forms, and global command palette
+- [Kernel] One service API surface (`/state`, `/events`, `/actions`) with no side channels
+- [Kernel] Single SQLite journal with content-addressed blobs; derive read-models and caches
+- [Kernel] Job model & scheduler as the only execution path; unify local and remote runners
+- [Kernel] Patch engine for all writes with diff preview and rollback
+- [Kernel] Documented event taxonomy; views/read-models subscribe to the event stream
+- [Kernel] Flows as DAG data executed by a single flow-runner; tools are schema-defined nodes
+- [Kernel] Unified retrieval pipeline and memory abstraction (vector/graph/kv/doc) with shared CRUD/stats and index hygiene
+- [Kernel] Capability/lease system with node-local egress proxy; remove per-tool allowlists
+- [Kernel] UI: shared right-sidecar, schema-generated forms, and global command palette
 
 Never‑Out‑Of‑Context (High Priority)
-- [t-250912143001-0001] Context Working Set doc + mkdocs nav — done (this change)
-- [t-250912143005-0002] Context API: allow slot budgets and return stable pointers (IDs) for all included items — todo
-- [t-250912143009-0003] Retrieval: add MMR‑style selector across vector/graph mounts and world beliefs — todo
-- [t-250912143013-0004] Compression cascade: summarize episodes (extract→abstract→outline) into mounts with provenance — todo
-- [t-250912143017-0005] Failure detectors: emit `context.recall_risk` and `context.coverage` with meters in UI — todo
-- [t-250912143021-0006] Memory hygiene: per‑lane caps + TTL + janitor job with rollups and evictions — todo
-- [t-250912143025-0007] Logic Unit: ship config‑only Never‑Out‑Of‑Context defaults (budgets, diversity, rehydrate rules) — todo
-- [t-250912143029-0008] UI: Project Hub panel “What’s in context now” with artifact pointers and rehydrate actions — todo
-- [t-250912143033-0009] Training Park: dials for diversity/recency/compression; recall‑risk and coverage meters — todo
+- [Pack: Research] [t-250912143001-0001] Context Working Set doc + mkdocs nav — done (this change)
+- [Pack: Research] [t-250912143005-0002] Context API: allow slot budgets and return stable pointers (IDs) for all included items — todo
+- [Pack: Research] [t-250912143009-0003] Retrieval: add MMR‑style selector across vector/graph mounts and world beliefs — todo
+- [Pack: Research] [t-250912143013-0004] Compression cascade: summarize episodes (extract→abstract→outline) into mounts with provenance — todo
+- [Pack: Research] [t-250912143017-0005] Failure detectors: emit `context.recall_risk` and `context.coverage` with meters in UI — todo
+- [Pack: Research] [t-250912143021-0006] Memory hygiene: per‑lane caps + TTL + janitor job with rollups and evictions — todo
+- [Pack: Research] [t-250912143025-0007] Logic Unit: ship config‑only Never‑Out‑Of‑Context defaults (budgets, diversity, rehydrate rules) — todo
+- [Pack: Research] [t-250912143029-0008] UI: Project Hub panel “What’s in context now” with artifact pointers and rehydrate actions — todo
+- [Pack: Research] [t-250912143033-0009] Training Park: dials for diversity/recency/compression; recall‑risk and coverage meters — todo
 
 UI Coherence
-- Universal right‑sidecar across Hub/Chat/Training; subscribe once to `/events` — done (initial lanes)
-- Command Palette: global search + actions; attach agent to project; grant scoped permissions with TTL — done (initial)
-- Compare: Hub Text/JSON (Only changes/Wrap/Copy), Image slider, CSV/Table key‑diff — done
-- Compare: Chat A/B pin‑to‑compare and diff — done
-- Events window: presets (state/models/tools/egress/feedback), include/exclude body filters, pretty/wrap/pause — done
-- Events window: RPU preset (rpu.*) — done
-- Logs window: route filter and focus tables mode — done
-- Screenshots: precise screen/window/region capture (with preview), sidecar Activity thumbnails — done
-- OCR: default‑on build with Tesseract; Auto OCR toggle in Chat; palette toggle — done
-- Gallery: modal with Open/Copy/Copy MD/Save to project/Annotate — done
-- Annotation overlay: draw rectangles; blur+border burn; sidecar JSON — done
-- Save to project: server import endpoint; path prompt; toast feedback — done
-- Project Hub (Files): breadcrumbs + Back; filter; inline expandable tree with persisted expansions; drag‑and‑drop upload; per‑project editor overrides; Open in Editor flow — done
-- Project Hub (Files): notes autosave with inline status; conflict‑aware merge UI with diff + scroll‑sync — done
-- Project Hub (Files): expand‑on‑search (auto‑expand ancestors of matches) and match highlighting — done
-- Project Hub (Runs): Pin‑to‑compare available; filters are non‑persistent (view‑only) — done
-- Accessibility: tree roles/aria‑level/expanded; regions labeled; command palette and gallery as dialogs; focus ring on rows; Compare tabs with role=tablist and roving tabindex — done
-- Routes: canonicalize admin UI paths (`/admin/debug`, `/admin/ui/*`); keep local dev alias `/debug`; update launcher open path — doing
-- SSE store: add connection status + resilient auto-reconnect with modest backoff; reuse filters and replay across reconnect — doing
-- Connections window: allow per-connection admin token; open Events/Logs/Models windows pointed at that base — todo
-- Per‑project templates: save/apply lanes/grid/focus in Hub — done
-- Route SLO selector UI: adjustable p95 threshold in Logs/Events — done
-- Export CSV: route/kind tables — done; table diff export — done (two‑row or wide)
-- Next: labels/arrows in annotator; redaction presets (regex+OCR); append Markdown to NOTES.md; Pin‑to‑compare from Runs; retention/tagging for gallery; guided countdown for capture.
- - Next: keyboard shortcuts (global) cheatsheet and discoverability; ARIA polish for Agents/Runs actions; skip‑links across pages; unit tests for /projects/file content_b64 path; virtualize large trees.
+- [Pack: Collaboration] Universal right‑sidecar across Hub/Chat/Training; subscribe once to `/events` — done (initial lanes)
+- [Pack: Collaboration] Command Palette: global search + actions; attach agent to project; grant scoped permissions with TTL — done (initial)
+- [Pack: Collaboration] Compare: Hub Text/JSON (Only changes/Wrap/Copy), Image slider, CSV/Table key‑diff — done
+- [Pack: Collaboration] Compare: Chat A/B pin‑to‑compare and diff — done
+- [Pack: Collaboration] Events window: presets (state/models/tools/egress/feedback), include/exclude body filters, pretty/wrap/pause — done
+- [Pack: Collaboration] Events window: RPU preset (rpu.*) — done
+- [Pack: Collaboration] Logs window: route filter and focus tables mode — done
+- [Pack: Collaboration] Screenshots: precise screen/window/region capture (with preview), sidecar Activity thumbnails — done
+- [Pack: Collaboration] OCR: default‑on build with Tesseract; Auto OCR toggle in Chat; palette toggle — done
+- [Pack: Collaboration] Gallery: modal with Open/Copy/Copy MD/Save to project/Annotate — done
+- [Pack: Collaboration] Annotation overlay: draw rectangles; blur+border burn; sidecar JSON — done
+- [Pack: Collaboration] Save to project: server import endpoint; path prompt; toast feedback — done
+- [Pack: Collaboration] Project Hub (Files): breadcrumbs + Back; filter; inline expandable tree with persisted expansions; drag‑and‑drop upload; per‑project editor overrides; Open in Editor flow — done
+- [Pack: Collaboration] Project Hub (Files): notes autosave with inline status; conflict‑aware merge UI with diff + scroll‑sync — done
+- [Pack: Collaboration] Project Hub (Files): expand‑on‑search (auto‑expand ancestors of matches) and match highlighting — done
+- [Pack: Collaboration] Project Hub (Runs): Pin‑to‑compare available; filters are non‑persistent (view‑only) — done
+- [Pack: Collaboration] Accessibility: tree roles/aria‑level/expanded; regions labeled; command palette and gallery as dialogs; focus ring on rows; Compare tabs with role=tablist and roving tabindex — done
+- [Pack: Collaboration] Routes: canonicalize admin UI paths (`/admin/debug`, `/admin/ui/*`); keep local dev alias `/debug`; update launcher open path — doing
+- [Pack: Collaboration] SSE store: add connection status + resilient auto-reconnect with modest backoff; reuse filters and replay across reconnect — doing
+- [Pack: Collaboration] Connections window: allow per-connection admin token; open Events/Logs/Models windows pointed at that base — todo
+- [Pack: Collaboration] Per‑project templates: save/apply lanes/grid/focus in Hub — done
+- [Pack: Collaboration] Route SLO selector UI: adjustable p95 threshold in Logs/Events — done
+- [Pack: Collaboration] Export CSV: route/kind tables — done; table diff export — done (two‑row or wide)
+- [Pack: Collaboration] Next: labels/arrows in annotator; redaction presets (regex+OCR); append Markdown to NOTES.md; Pin‑to‑compare from Runs; retention/tagging for gallery; guided countdown for capture.
+ - [Pack: Collaboration] Next: keyboard shortcuts (global) cheatsheet and discoverability; ARIA polish for Agents/Runs actions; skip‑links across pages; unit tests for /projects/file content_b64 path; virtualize large trees.
 
 Kernel & Triad (NOW)
-- [t-250915090001-kern01] Add `arw-kernel` crate with SQLite/WAL schema (events, artifacts, actions) and CAS helpers — done
-- [t-250915090010-kern02] Dual-write bus events to kernel and expose `/triad/events?replay=N` — done
-- [t-250915090020-kern03] Add `/actions` endpoint backed by kernel with idempotency and policy stub — todo
-- [t-250915090030-kern04] Add `/state/*` views sourced from kernel (episodes, route_stats, models) — todo
-- [t-250915090040-kern05] Migrate JSONL events journal to SQLite (remove old env) — plan
+- [Kernel] [t-250915090001-kern01] Add `arw-kernel` crate with SQLite/WAL schema (events, artifacts, actions) and CAS helpers — done
+- [Kernel] [t-250915090010-kern02] Dual-write bus events to kernel and expose `/triad/events?replay=N` — done
+- [Kernel] [t-250915090020-kern03] Add `/actions` endpoint backed by kernel with idempotency and policy stub — todo
+- [Kernel] [t-250915090030-kern04] Add `/state/*` views sourced from kernel (episodes, route_stats, models) — todo
+- [Kernel] [t-250915090040-kern05] Migrate JSONL events journal to SQLite (remove old env) — plan
 
 Design System & Tokens
-- [t-250914231200-dsg01] Single‑source tokens (CSS/JSON) under `assets/design/` — done
-- [t-250914231205-dsg02] Sync helper and task (`scripts/sync_tokens.sh`, `just tokens-sync`) — done
-- [t-250914231210-dsg03] Docs: load tokens via `extra_css`; add Design Theme page — done
-- [t-250914231215-dsg04] Launcher: adopt tokens across common/index/events/logs/models/connections — done (initial)
-- [t-250914231220-dsg05] Service Debug UI: replace inline styles with token vars — in progress
-- [t-250914231225-dsg06] Docs overrides: dedupe variables; rely on tokens only — done
-- [t-250914231240-dsg09] CI: add tokens sync check step (uses `just tokens-check`) — done
-- [t-250914231230-dsg07] Extract `ui-kit.css` primitives (buttons/inputs/badges) for launcher pages — done
-- [t-250914231235-dsg08] Contrast audit (WCAG AA) sweep; adjust any low‑contrast cases — todo
-- [t-250914231245-dsg10] Add W3C tokens pipeline (Style Dictionary) to emit platform targets — plan
-- [t-250914231250-dsg11] Add prefers-contrast / forced-colors styles for key components — todo
- - [t-250914231255-dsg12] Tailwind tokens export (JSON) for downstream configs — done
+- [Pack: Collaboration] [t-250914231200-dsg01] Single‑source tokens (CSS/JSON) under `assets/design/` — done
+- [Pack: Collaboration] [t-250914231205-dsg02] Sync helper and task (`scripts/sync_tokens.sh`, `just tokens-sync`) — done
+- [Pack: Collaboration] [t-250914231210-dsg03] Docs: load tokens via `extra_css`; add Design Theme page — done
+- [Pack: Collaboration] [t-250914231215-dsg04] Launcher: adopt tokens across common/index/events/logs/models/connections — done (initial)
+- [Pack: Collaboration] [t-250914231220-dsg05] Service Debug UI: replace inline styles with token vars — in progress
+- [Pack: Collaboration] [t-250914231225-dsg06] Docs overrides: dedupe variables; rely on tokens only — done
+- [Pack: Collaboration] [t-250914231240-dsg09] CI: add tokens sync check step (uses `just tokens-check`) — done
+- [Pack: Collaboration] [t-250914231230-dsg07] Extract `ui-kit.css` primitives (buttons/inputs/badges) for launcher pages — done
+- [Pack: Collaboration] [t-250914231235-dsg08] Contrast audit (WCAG AA) sweep; adjust any low‑contrast cases — todo
+- [Pack: Collaboration] [t-250914231245-dsg10] Add W3C tokens pipeline (Style Dictionary) to emit platform targets — plan
+- [Pack: Collaboration] [t-250914231250-dsg11] Add prefers-contrast / forced-colors styles for key components — todo
+ - [Pack: Collaboration] [t-250914231255-dsg12] Tailwind tokens export (JSON) for downstream configs — done
 
 Standards & Docs
-- [t-250914231255-std01] Add ADR framework and seed first ADRs (tokens SSoT, event naming) — plan
- - [t-250914231300-std02] Optional docs a11y check in CI (axe) — done
+- [Kernel] [t-250914231255-std01] Add ADR framework and seed first ADRs (tokens SSoT, event naming) — plan
+ - [Kernel] [t-250914231300-std02] Optional docs a11y check in CI (axe) — done
 
 Recipes MVP
-- Finalize `spec/schemas/recipe_manifest.json`; add doc‑tests and example gallery entries
-- Gallery UI: install (copy folder), inspect manifest, launch, capture Episodes
-- Permission prompts (ask/allow/never) with TTL leases; audit decisions as `Policy.*` events
+- [Pack: Collaboration] Finalize `spec/schemas/recipe_manifest.json`; add doc‑tests and example gallery entries
+- [Pack: Collaboration] Gallery UI: install (copy folder), inspect manifest, launch, capture Episodes
+- [Pack: Collaboration] Permission prompts (ask/allow/never) with TTL leases; audit decisions as `Policy.*` events
 
 Logic Units (High Priority)
-- Manifest and schema (`spec/schemas/logic_unit_manifest.json`); example units under `examples/logic-units/`
-- Library UI: tabs (Installed/Experimental/Suggested/Archived), diff preview, apply/revert/promote
-- Agent Profile slots + compatibility checks (design + stubs)
-- A/B dry‑run pipeline wired to Evaluation Harness; per‑unit metrics panel
-- Research Watcher: ingest feeds; draft config‑only units; Suggested tab source
+- [Pack: Research] Manifest and schema (`spec/schemas/logic_unit_manifest.json`); example units under `examples/logic-units/`
+- [Pack: Research] Library UI: tabs (Installed/Experimental/Suggested/Archived), diff preview, apply/revert/promote
+- [Pack: Research] Agent Profile slots + compatibility checks (design + stubs)
+- [Pack: Research] A/B dry‑run pipeline wired to Evaluation Harness; per‑unit metrics panel
+- [Pack: Research] Research Watcher: ingest feeds; draft config‑only units; Suggested tab source
 
 Last‑mile Structures
-- Config Patch Engine: dry‑run/apply/revert endpoints; schema validation; audited permission widening
-- Experiment Orchestrator: start/stop/assign; emit Experiment.*; fold to `/state/experiments`
-- Provenance/Snapshots: enrich `/state/episode/{id}/snapshot` with effective config (units, params, model hash, policies)
-- AppSec Harness: seed tests; surface violations as `policy.decision` events; block unsafe tool I/O
-- Observability (OTel): map timeline to traces (corr_id as trace); correlate metrics/logs
-- Compliance Mode: workspace switch; record‑keeping + approvals; UI status widget
-- Supply‑Chain Trust: signed manifests, SBOMs, sandbox defaults; align desktop capabilities with policies
-- Scheduler/Governor: fair queues, preemption, backpressure, kill‑switch; policy‑aware
+- [Pack: Research] Config Patch Engine: dry‑run/apply/revert endpoints; schema validation; audited permission widening
+- [Pack: Research] Experiment Orchestrator: start/stop/assign; emit Experiment.*; fold to `/state/experiments`
+- [Pack: Research] Provenance/Snapshots: enrich `/state/episode/{id}/snapshot` with effective config (units, params, model hash, policies)
+- [Pack: Research] AppSec Harness: seed tests; surface violations as `policy.decision` events; block unsafe tool I/O
+- [Pack: Research] Observability (OTel): map timeline to traces (corr_id as trace); correlate metrics/logs
+- [Pack: Research] Compliance Mode: workspace switch; record‑keeping + approvals; UI status widget
+- [Pack: Research] Supply‑Chain Trust: signed manifests, SBOMs, sandbox defaults; align desktop capabilities with policies
+- [Pack: Research] Scheduler/Governor: fair queues, preemption, backpressure, kill‑switch; policy‑aware
 
 Security & Admin
-- Admin auth hardening — hashed tokens + per‑token/IP sliding rate‑limit [t-250911230312-0863]
-- Per‑route gating layers; slim global admin middleware [t-250911230252-9858]
-- Supply‑chain: upgrade GTK/GLib stack to >=0.20 (via wry/gtk/tao/tauri) to resolve RUSTSEC-2024-0429; remove temporary ignore in `deny.toml` and audit script guard once lockfile carries `glib >= 0.20.0`.
+- [Kernel] Admin auth hardening — hashed tokens + per‑token/IP sliding rate‑limit [t-250911230312-0863]
+- [Kernel] Per‑route gating layers; slim global admin middleware [t-250911230252-9858]
+- [Kernel] Supply‑chain: upgrade GTK/GLib stack to >=0.20 (via wry/gtk/tao/tauri) to resolve RUSTSEC-2024-0429; remove temporary ignore in `deny.toml` and audit script guard once lockfile carries `glib >= 0.20.0`.
 
-- Asimov Capsule Guard (plan)
- - [t-250916130001-asg01] RPU telemetry + `/state/policy/capsules` read-model surfacing adoption and TTL — todo
- - [t-250916130002-asg02] Layered gating denies/contracts with lease sweeper + emergency teardown hook — plan
- - [t-250916130003-asg03] Auto-replay verified capsules before actions/tools/egress/policy evaluation — plan
- - [t-250916130004-asg04] Admin UX + CLI for capsule presets, rotation, and audit trails — plan
+- [Kernel] Asimov Capsule Guard (plan)
+ - [Kernel] [t-250916130001-asg01] RPU telemetry + `/state/policy/capsules` read-model surfacing adoption and TTL — todo
+ - [Kernel] [t-250916130002-asg02] Layered gating denies/contracts with lease sweeper + emergency teardown hook — plan
+ - [Kernel] [t-250916130003-asg03] Auto-replay verified capsules before actions/tools/egress/policy evaluation — plan
+ - [Kernel] [t-250916130004-asg04] Admin UX + CLI for capsule presets, rotation, and audit trails — plan
 
 Caching & Performance (High Priority)
-- [t-250913001000-1001] Llama.cpp prompt cache: set `cache_prompt: true` in requests; doc server `--prompt-cache` for persistence — in progress
-- [t-250913001003-1002] CAS HTTP caching: add `ETag`, `Last-Modified`, long‑lived `Cache-Control`, and 304 handling to `/admin/models/by-hash/{sha256}` — done
-- [t-250913001006-1003] Action Cache (MVP): wrap `tools_exec::run` with deterministic key (tool id, version, canonical JSON, env signature stub) and CAS’d outputs; Moka front with TTL; `tool.cache` events — in progress
-- [t-250913001009-1004] Singleflight: coalesce identical in‑flight tool runs and expensive read‑model recomputes — todo
-- [t-250913001012-1005] Read‑models SSE deltas: stream JSON Patch with `Last-Event-ID` resume; wire Debug UI to apply patches — todo
-- [t-250913001015-1006] Metrics: expose cache hit/miss/age, bytes/latency saved, stampede suppression rate at `/state/*` and `/metrics` — todo
-- [t-250913001018-1007] Cache Policy manifest + loader: define YAML format, map to env knobs, and plan migration to config‑first overrides — docs done; loader todo
-- [t-250914210100-http01] HTTP helpers module (`ext::http`) for ETag/Last‑Modified/Range parsing; adopt in models blob GET/HEAD — done
-- [t-250914210104-http02] Adopt `ext::http` helpers across any future digest/static file endpoints (keep semantics consistent) — todo
-- [t-250914210107-http03] Docs: consolidate HTTP caching semantics into a short reusable snippet and cross‑link from API/Guide — done
+- [Kernel] [t-250913001000-1001] Llama.cpp prompt cache: set `cache_prompt: true` in requests; doc server `--prompt-cache` for persistence — in progress
+- [Kernel] [t-250913001003-1002] CAS HTTP caching: add `ETag`, `Last-Modified`, long‑lived `Cache-Control`, and 304 handling to `/admin/models/by-hash/{sha256}` — done
+- [Kernel] [t-250913001006-1003] Action Cache (MVP): wrap `tools_exec::run` with deterministic key (tool id, version, canonical JSON, env signature stub) and CAS’d outputs; Moka front with TTL; `tool.cache` events — in progress
+- [Kernel] [t-250913001009-1004] Singleflight: coalesce identical in‑flight tool runs and expensive read‑model recomputes — todo
+- [Kernel] [t-250913001012-1005] Read‑models SSE deltas: stream JSON Patch with `Last-Event-ID` resume; wire Debug UI to apply patches — todo
+- [Kernel] [t-250913001015-1006] Metrics: expose cache hit/miss/age, bytes/latency saved, stampede suppression rate at `/state/*` and `/metrics` — todo
+- [Kernel] [t-250913001018-1007] Cache Policy manifest + loader: define YAML format, map to env knobs, and plan migration to config‑first overrides — docs done; loader todo
+- [Kernel] [t-250914210100-http01] HTTP helpers module (`ext::http`) for ETag/Last‑Modified/Range parsing; adopt in models blob GET/HEAD — done
+- [Kernel] [t-250914210104-http02] Adopt `ext::http` helpers across any future digest/static file endpoints (keep semantics consistent) — todo
+- [Kernel] [t-250914210107-http03] Docs: consolidate HTTP caching semantics into a short reusable snippet and cross‑link from API/Guide — done
 
 Egress Firewall & Posture (Plan)
-- Policy: add network scopes (domain/IP/CIDR, port, protocol) and TTL leases; surface in UI.
-- Gateway: per‑node loopback proxy (HTTP(S)/WS CONNECT; optional SOCKS5) with allow/deny by SNI/Host and port; deny IP‑literals by default; no TLS MITM.
-- DNS Guard: force resolver, block UDP/53/DoH/DoT from tools; short TTLs; log lookups.
-- Routing: containers via proxy env + blocked direct egress; host processes with OS firewall rules (allow 127.0.0.1:proxy only for agent PIDs).
-- Ledger: append‑only egress ledger with episode/project/node attribution and bytes/$ estimates; pre‑offload preview dialog in UI.
-- Posture: Off/Public/Allowlist/Custom per project; default to Public.
-- Filesystem & Sensors: sandbox write scopes (project://) and leased mic/cam sidecar access with TTL + audits.
-- Cluster: replicate gateway+DNS guard per Worker; propagate policies from Home over mTLS; Workers cannot widen scope.
+- [Kernel] Policy: add network scopes (domain/IP/CIDR, port, protocol) and TTL leases; surface in UI.
+- [Kernel] Gateway: per‑node loopback proxy (HTTP(S)/WS CONNECT; optional SOCKS5) with allow/deny by SNI/Host and port; deny IP‑literals by default; no TLS MITM.
+- [Kernel] DNS Guard: force resolver, block UDP/53/DoH/DoT from tools; short TTLs; log lookups.
+- [Kernel] Routing: containers via proxy env + blocked direct egress; host processes with OS firewall rules (allow 127.0.0.1:proxy only for agent PIDs).
+- [Kernel] Ledger: append‑only egress ledger with episode/project/node attribution and bytes/$ estimates; pre‑offload preview dialog in UI.
+- [Kernel] Posture: Off/Public/Allowlist/Custom per project; default to Public.
+- [Kernel] Filesystem & Sensors: sandbox write scopes (project://) and leased mic/cam sidecar access with TTL + audits.
+- [Kernel] Cluster: replicate gateway+DNS guard per Worker; propagate policies from Home over mTLS; Workers cannot widen scope.
 
 Lightweight Mitigations (Plan)
-- Memory quarantine: add review queue and `memory.quarantined`/`memory.admitted` events; admit only with provenance + evidence score.
-- Project isolation: enforce per‑project namespaces for caches/embeddings/indexes; “export views” only; imports read‑only and revocable.
-- Belief‑graph ingest: queue world diffs; surface conflicts; require accept/apply with audit events.
-- Cluster manifest pinning: define signed manifest schema; publish/verify; scheduler filters to trusted manifests.
-- Secrets hygiene: vault‑only; redaction pass on snapshots/egress previews; secret‑scanner job for artifacts.
-- Hardened headless browsing: disable service workers/HTTP3; same‑origin fetches; DOM‑to‑text extractor; route via proxy.
-- Safe archive handling: temp jail extraction with path canonicalization; size/time caps; nested depth limit.
-- DNS guard + anomaly: rate‑limit lookups; alert on high‑entropy domain bursts.
-- Accelerator hygiene: zero VRAM/buffers between jobs; disable persistence mode where possible; prefer per‑job processes.
-- Co‑drive role separation: roles view/suggest/drive; “drive” cannot widen scope or approve leases; tag remote actions.
-- Event integrity: mTLS; nonces; monotonic sequence numbers; idempotent actions; reject out‑of‑order/duplicates.
-- Context rehydration guard: redaction/classification before reuse in prompts; badge “potentially exportable”; require egress lease if offloaded.
-- Operational guardrails: per‑project security posture (Relaxed/Standard/Strict); egress ledger retention + daily review UI; one‑click revoke.
-- Hygiene cadence: quarterly key rotation & re‑sign; monthly dependency sweep with golden tests & snapshot diffs.
-- Seeded red‑team tests in CI: prompt‑injection, zip‑slip, SSRF, secrets‑in‑logs detector.
+- [Kernel] Memory quarantine: add review queue and `memory.quarantined`/`memory.admitted` events; admit only with provenance + evidence score.
+- [Kernel] Project isolation: enforce per‑project namespaces for caches/embeddings/indexes; “export views” only; imports read‑only and revocable.
+- [Kernel] Belief‑graph ingest: queue world diffs; surface conflicts; require accept/apply with audit events.
+- [Kernel] Cluster manifest pinning: define signed manifest schema; publish/verify; scheduler filters to trusted manifests.
+- [Kernel] Secrets hygiene: vault‑only; redaction pass on snapshots/egress previews; secret‑scanner job for artifacts.
+- [Kernel] Hardened headless browsing: disable service workers/HTTP3; same‑origin fetches; DOM‑to‑text extractor; route via proxy.
+- [Kernel] Safe archive handling: temp jail extraction with path canonicalization; size/time caps; nested depth limit.
+- [Kernel] DNS guard + anomaly: rate‑limit lookups; alert on high‑entropy domain bursts.
+- [Kernel] Accelerator hygiene: zero VRAM/buffers between jobs; disable persistence mode where possible; prefer per‑job processes.
+- [Kernel] Co‑drive role separation: roles view/suggest/drive; “drive” cannot widen scope or approve leases; tag remote actions.
+- [Kernel] Event integrity: mTLS; nonces; monotonic sequence numbers; idempotent actions; reject out‑of‑order/duplicates.
+- [Kernel] Context rehydration guard: redaction/classification before reuse in prompts; badge “potentially exportable”; require egress lease if offloaded.
+- [Kernel] Operational guardrails: per‑project security posture (Relaxed/Standard/Strict); egress ledger retention + daily review UI; one‑click revoke.
+- [Kernel] Hygiene cadence: quarterly key rotation & re‑sign; monthly dependency sweep with golden tests & snapshot diffs.
+- [Kernel] Seeded red‑team tests in CI: prompt‑injection, zip‑slip, SSRF, secrets‑in‑logs detector.
 
 Remote Access & TLS
-- Dev TLS profiles (mkcert + self‑signed) for localhost
-- Caddy production profile with Let's Encrypt (HTTP‑01/DNS‑01) for public domains
-- Reverse‑proxy templates (nginx/caddy) with quick run/stop helpers
-- Secrets handling: persist admin tokens only to local env files; avoid committing to configs
-- Setup wizards to pick domain/email, validate DNS, and dry‑run cert issuance
+- [Kernel] Dev TLS profiles (mkcert + self‑signed) for localhost
+- [Kernel] Caddy production profile with Let's Encrypt (HTTP‑01/DNS‑01) for public domains
+- [Kernel] Reverse‑proxy templates (nginx/caddy) with quick run/stop helpers
+- [Kernel] Secrets handling: persist admin tokens only to local env files; avoid committing to configs
+- [Kernel] Setup wizards to pick domain/email, validate DNS, and dry‑run cert issuance
 
 Observability & Eventing
-- Event journal: reader endpoint (tail N) and topic‑filtered consumers across workers/connectors
-- Metrics registry with histograms; wire to /metrics [t-250911230320-8615]
-- Docs: surface route metrics/events in docs and status page — done
-- RPU trust: watcher + endpoints + `rpu.trust.changed` event + Prometheus gauges — done
+- [Kernel] Event journal: reader endpoint (tail N) and topic‑filtered consumers across workers/connectors
+- [Kernel] Metrics registry with histograms; wire to /metrics [t-250911230320-8615]
+- [Kernel] Docs: surface route metrics/events in docs and status page — done
+- [Pack: Collaboration] RPU trust: watcher + endpoints + `rpu.trust.changed` event + Prometheus gauges — done
 
 Compatibility & Hardware
-- GPU probe fallback via wgpu: enumerate adapters across backends — done
+- [Kernel] GPU probe fallback via wgpu: enumerate adapters across backends — done
 
 State Read‑Models & Episodes
-- Observations read‑model + GET /state/observations [t-250912001055-0044]
-- Beliefs/Intents/Actions stores + endpoints [t-250912001100-3438]
-- Episodes + Debug UI reactive views (truth window) [t-250912001105-7850]
-- Debug UI: Episodes filters + details toggle [t-250912024838-4137]
+- [Kernel] Observations read‑model + GET /state/observations [t-250912001055-0044]
+- [Kernel] Beliefs/Intents/Actions stores + endpoints [t-250912001100-3438]
+- [Kernel] Episodes + Debug UI reactive views (truth window) [t-250912001105-7850]
+- [Kernel] Debug UI: Episodes filters + details toggle [t-250912024838-4137]
 
 Hierarchy & Governor Services
-- Encapsulate hierarchy (hello/offer/accept/state/role_set) and governor (profile/hints) into typed services; endpoints prefer services; publish corr_id events; persist orchestration [t-250912024843-7597]
+- [Kernel] Encapsulate hierarchy (hello/offer/accept/state/role_set) and governor (profile/hints) into typed services; endpoints prefer services; publish corr_id events; persist orchestration [t-250912024843-7597]
 
 CLI & Introspection
-- Migrate arw-cli to clap (derive, help, completions, JSON flag) [t-250911230329-4722]
-- Auto‑generate /about endpoints from router/introspection [t-250911230306-7961] — done
-  - /about merges public endpoints (runtime recorder) and admin endpoints (macro registry); entries are `METHOD path`; deduped and sorted.
+- [Kernel] Migrate arw-cli to clap (derive, help, completions, JSON flag) [t-250911230329-4722]
+- [Kernel] Auto‑generate /about endpoints from router/introspection [t-250911230306-7961] — done
+  - [Kernel] /about merges public endpoints (runtime recorder) and admin endpoints (macro registry); entries are `METHOD path`; deduped and sorted.
 
 Queues, NATS & Orchestration
-- Orchestrator: lease handling, nack(retry_after_ms), group max in‑flight + tests [t-250911230308-0779]
-- NATS: TLS/auth config and reconnect/backoff tuning; docs and examples [t-250911230316-4765]
+- [Kernel] Orchestrator: lease handling, nack(retry_after_ms), group max in‑flight + tests [t-250911230308-0779]
+- [Kernel] NATS: TLS/auth config and reconnect/backoff tuning; docs and examples [t-250911230316-4765]
 
 Specs & Docs
-- Generate AsyncAPI + MCP artifacts and serve under /spec/* [t-250909224102-9629]
-- Docgen: gating keys listing + config schema and examples
-- AsyncAPI: include `rpu.trust.changed` channel — done
-- Event normalization rollout
-  - [t-250913213500-ev01] Add dual-mode warning logs when ARW_EVENTS_KIND_MODE=dual to surface remaining legacy consumers — removed (modes dropped)
-  - [t-250913213501-ev02] Update all docs/screenshots/snippets to normalized kinds (models.download.progress, …) — in progress
-  - Gallery guide and screenshots guide updates — done
-  - [t-250913213502-ev03] Add envelope schema `ApiEnvelope<T>` in OpenAPI and adopt in responses (opt-in) — todo
-  - [t-250913213503-ev04] Add short descriptions to any endpoints with Spectral hints (e.g., /state/models) — done
-  - [t-250913213504-ev05] Adjust Spectral AsyncAPI rule to accept dot.case explicitly to remove naming warnings — todo
-  - [t-250913213505-ev06] Plan removal: switch all deployments to normalized kinds, then drop legacy/dual paths — done
-  - [t-250913213506-ev07] Add deprecation note to release notes (legacy event kinds) — done
+- [Kernel] Generate AsyncAPI + MCP artifacts and serve under /spec/* [t-250909224102-9629]
+- [Kernel] Docgen: gating keys listing + config schema and examples
+- [Kernel] AsyncAPI: include `rpu.trust.changed` channel — done
+- [Kernel] Event normalization rollout
+  - [Kernel] [t-250913213500-ev01] Add dual-mode warning logs when ARW_EVENTS_KIND_MODE=dual to surface remaining legacy consumers — removed (modes dropped)
+  - [Kernel] [t-250913213501-ev02] Update all docs/screenshots/snippets to normalized kinds (models.download.progress, …) — in progress
+  - [Kernel] Gallery guide and screenshots guide updates — done
+  - [Kernel] [t-250913213502-ev03] Add envelope schema `ApiEnvelope<T>` in OpenAPI and adopt in responses (opt-in) — todo
+  - [Kernel] [t-250913213503-ev04] Add short descriptions to any endpoints with Spectral hints (e.g., /state/models) — done
+  - [Kernel] [t-250913213504-ev05] Adjust Spectral AsyncAPI rule to accept dot.case explicitly to remove naming warnings — todo
+  - [Kernel] [t-250913213505-ev06] Plan removal: switch all deployments to normalized kinds, then drop legacy/dual paths — done
+  - [Kernel] [t-250913213506-ev07] Add deprecation note to release notes (legacy event kinds) — done
 
 Visual Capture (Screenshots)
-- Screenshot tool (OS‑level): capture entire screen/display or region; save to `.arw/screenshots/` and emit `screenshots.captured` — done
-- Window crop: obtain Tauri window bounds and crop screenshot to window rectangle — done
-- OCR pass (optional): run OCR over captured region (tesseract/rapidocr) to extract text for search — in progress (feature‑flag ready; enabled by default)
-- Sidecar: Activity lane shows recent screenshots as thumbnails with open/copy actions — done
-- Annotation: overlay + burn tool with sidecar JSON; blur+border — done
-- Gallery: modal with actions and annotate — done
-- Policy: gate under `io:screenshot` and `io:ocr`; leases and audit — done
-- Next: redaction presets; labels/arrows; retention and search in gallery; Save to project macro to append Markdown in NOTES.md.
+- [Pack: Collaboration] Screenshot tool (OS‑level): capture entire screen/display or region; save to `.arw/screenshots/` and emit `screenshots.captured` — done
+- [Pack: Collaboration] Window crop: obtain Tauri window bounds and crop screenshot to window rectangle — done
+- [Pack: Collaboration] OCR pass (optional): run OCR over captured region (tesseract/rapidocr) to extract text for search — in progress (feature‑flag ready; enabled by default)
+- [Pack: Collaboration] Sidecar: Activity lane shows recent screenshots as thumbnails with open/copy actions — done
+- [Pack: Collaboration] Annotation: overlay + burn tool with sidecar JSON; blur+border — done
+- [Pack: Collaboration] Gallery: modal with actions and annotate — done
+- [Pack: Collaboration] Policy: gate under `io:screenshot` and `io:ocr`; leases and audit — done
+- [Pack: Collaboration] Next: redaction presets; labels/arrows; retention and search in gallery; Save to project macro to append Markdown in NOTES.md.
 
 Strict dot.case normalization (no back-compat)
-- [t-250914050900-ev10] Update topics SSoT to dot.case only (remove CamelCase constants) — in progress
-- [t-250914050902-ev11] Replace all publishers to use topics.rs constants (no hard-coded strings) — in progress
-- [t-250914050904-ev12] Debug UI: switch listeners to dot.case only — todo
-- [t-250914050906-ev13] Connector: publish `task.completed` and subjects `arw.events.task.completed` + node variant — todo
-- [t-250914050908-ev14] Update Feature Matrix topics to dot.case — in progress
-- [t-250914050910-ev15] Docs: update Events Vocabulary/Topics/Admin Endpoints to dot.case — todo
-- [t-250914050912-ev16] CI linter: fail on any `publish("...CamelCase...")` or legacy subjects — todo
-- [t-250914050914-ev17] arw-core gating keys: add `events:task.completed` and update callers — plan
-- [t-250914050916-ev18] Release notes: breaking change, mapping table, migration notes — todo
+- [Kernel] [t-250914050900-ev10] Update topics SSoT to dot.case only (remove CamelCase constants) — in progress
+- [Kernel] [t-250914050902-ev11] Replace all publishers to use topics.rs constants (no hard-coded strings) — in progress
+- [Kernel] [t-250914050904-ev12] Debug UI: switch listeners to dot.case only — todo
+- [Kernel] [t-250914050906-ev13] Connector: publish `task.completed` and subjects `arw.events.task.completed` + node variant — todo
+- [Kernel] [t-250914050908-ev14] Update Feature Matrix topics to dot.case — in progress
+- [Kernel] [t-250914050910-ev15] Docs: update Events Vocabulary/Topics/Admin Endpoints to dot.case — todo
+- [Kernel] [t-250914050912-ev16] CI linter: fail on any `publish("...CamelCase...")` or legacy subjects — todo
+- [Kernel] [t-250914050914-ev17] arw-core gating keys: add `events:task.completed` and update callers — plan
+- [Kernel] [t-250914050916-ev18] Release notes: breaking change, mapping table, migration notes — todo
 
 OpenAPI/Examples
-- [t-250913213507-api01] Add examples for /admin/models/jobs and /admin/models/download responses — done
-- [t-250913213508-api02] Document public /state/models envelope explicitly or add note about envelope omission in examples — todo
+- [Kernel] [t-250913213507-api01] Add examples for /admin/models/jobs and /admin/models/download responses — done
+- [Kernel] [t-250913213508-api02] Document public /state/models envelope explicitly or add note about envelope omission in examples — todo
 
 Feedback Engine (Near‑Live)
-- Engine crate and integration: actor with O(1) stats, deltas via bus, snapshot+persistence [t-250909224102-8952]
-- UI: near‑live feedback in /debug showing deltas with rationale/confidence [t-250909224103-0211]
-- Policy hook: shadow → policy‑gated auto‑apply with bounds/rate‑limits [t-250909224103-5251]
+- [Pack: Collaboration] Engine crate and integration: actor with O(1) stats, deltas via bus, snapshot+persistence [t-250909224102-8952]
+- [Pack: Collaboration] UI: near‑live feedback in /debug showing deltas with rationale/confidence [t-250909224103-0211]
+- [Pack: Collaboration] Policy hook: shadow → policy‑gated auto‑apply with bounds/rate‑limits [t-250909224103-5251]
 
 Testing
-- End‑to‑end coverage for endpoints & gating; fixtures; CI integration [t-250911230325-2116]
-- [t-250914210200-test01] Scoped state dir for tests (`test_support::scoped_state_dir`) to isolate `ARW_STATE_DIR` — done
-- [t-250914210204-test02] Migrate env‑derived `state_dir` lookups to a process‑lifetime cache (OnceCell) with a test‑only reset hook to avoid flakiness — todo
-- [t-250914210208-test03] Concurrency controls: add tests for `block=false` shrink path and pending_shrink reporting — todo
+- [Kernel] End‑to‑end coverage for endpoints & gating; fixtures; CI integration [t-250911230325-2116]
+- [Kernel] [t-250914210200-test01] Scoped state dir for tests (`test_support::scoped_state_dir`) to isolate `ARW_STATE_DIR` — done
+- [Kernel] [t-250914210204-test02] Migrate env‑derived `state_dir` lookups to a process‑lifetime cache (OnceCell) with a test‑only reset hook to avoid flakiness — todo
+- [Kernel] [t-250914210208-test03] Concurrency controls: add tests for `block=false` shrink path and pending_shrink reporting — todo
 
 Stabilization & Contracts
-- [t-250914210300-api01] Models summary: switch handler to typed snapshots from `ModelsService` (avoid ad‑hoc JSON picks) — done
-- [t-250914210302-api06] Concurrency: expose `pending_shrink` in `GET /admin/models/concurrency` and jobs snapshot — done
-- [t-250914210303-ui01] Models UI: add Jobs panel, concurrency controls with feedback, Installed Hashes filters + reset, and persistence — done
-- [t-250914210304-ui02] Installed Hashes: add pagination controls (offset/next/prev) — todo
-- [t-250914210304-api02] Egress ledger: add compact summarizer endpoint (time‑bounded; filters by decision/reason) — done
-- [t-250914210308-api03] CAS GC: centralize manifest reference extraction (single helper used by GC and any scanners) — todo
-- [t-250914210312-api04] Contract tests: promote spec/docs consistency checks to CI (status/code enums already validated in unit tests) — todo
-- [t-250914210316-api05] Sweep and remove any remaining deprecated endpoints; update docs and SDKs — todo
+- [Kernel] [t-250914210300-api01] Models summary: switch handler to typed snapshots from `ModelsService` (avoid ad‑hoc JSON picks) — done
+- [Kernel] [t-250914210302-api06] Concurrency: expose `pending_shrink` in `GET /admin/models/concurrency` and jobs snapshot — done
+- [Kernel] [t-250914210303-ui01] Models UI: add Jobs panel, concurrency controls with feedback, Installed Hashes filters + reset, and persistence — done
+- [Kernel] [t-250914210304-ui02] Installed Hashes: add pagination controls (offset/next/prev) — todo
+- [Kernel] [t-250914210304-api02] Egress ledger: add compact summarizer endpoint (time‑bounded; filters by decision/reason) — done
+- [Kernel] [t-250914210308-api03] CAS GC: centralize manifest reference extraction (single helper used by GC and any scanners) — todo
+- [Kernel] [t-250914210312-api04] Contract tests: promote spec/docs consistency checks to CI (status/code enums already validated in unit tests) — todo
+- [Kernel] [t-250914210316-api05] Sweep and remove any remaining deprecated endpoints; update docs and SDKs — todo
 
 ## Next (1–2 Months)
 
 Platform & Policy
-- WASI plugin sandbox: capability‑based tool permissions (ties to Policy)
-- Policy engine integration (Cedar bindings); per‑tool permission manifests
-- RPU: trust‑store watch + stronger verification; introspection endpoint [t-250911230333-9794]
+- [Kernel] WASI plugin sandbox: capability‑based tool permissions (ties to Policy)
+- [Kernel] Policy engine integration (Cedar bindings); per‑tool permission manifests
+- [Pack: Collaboration] RPU: trust‑store watch + stronger verification; introspection endpoint [t-250911230333-9794]
 
 Models & Orchestration
-- Model orchestration adapters (llama.cpp, ONNX Runtime) with pooling and profiles
-- Capsules: record inputs/outputs/events/hints; export/import; deterministic replay
+- [Kernel] Model orchestration adapters (llama.cpp, ONNX Runtime) with pooling and profiles
+- [Pack: Research] Capsules: record inputs/outputs/events/hints; export/import; deterministic replay
 
 Specs & Interop
-- AsyncAPI + MCP artifacts in CI; promote developer experience around /spec/*
+- [Kernel] AsyncAPI + MCP artifacts in CI; promote developer experience around /spec/*
 
 Docs & Distribution
-- Showcase readiness: polish docs, packaging, and installer paths
+- [Pack: Collaboration] Showcase readiness: polish docs, packaging, and installer paths
 
 ## Notes
-- For live status of all tracked tasks, see Developer → Tasks, which renders from `.arw/tasks.json`.
-- Recently shipped work is summarized under About → Roadmap → Recently Shipped.
+- [Kernel] For live status of all tracked tasks, see Developer → Tasks, which renders from `.arw/tasks.json`.
+- [Kernel] Recently shipped work is summarized under About → Roadmap → Recently Shipped.

--- a/docs/INTERFACE_ROADMAP.md
+++ b/docs/INTERFACE_ROADMAP.md
@@ -12,31 +12,31 @@ See also: [Roadmap](ROADMAP.md)
 This roadmap consolidates user-facing interface concepts to guide a unified, accessible experience across the service, launcher, and debug tooling.
 
 ## Short‑Term (0–3 Months)
-- Guided micro-tutorials for first-time features
-- Micro-satisfaction elements (light animations, haptic feedback)
-- Contextual launcher tray actions with recent commands
-- Inline doc hints and contextual tooltips
-- Command palette/quick-action menu in the launcher
- - Canonical admin routes: `/admin/debug`, `/admin/ui/*` (keep clear dev aliases)
- - SSE robustness: status badges + auto-reconnect with backoff and Last-Event-ID resume
- - Connections: per-connection admin token and open app windows for that base
- - Schema-generated forms from OpenAPI for consistent parameter UIs
+- [Pack: Collaboration] Guided micro-tutorials for first-time features
+- [Pack: Collaboration] Micro-satisfaction elements (light animations, haptic feedback)
+- [Pack: Collaboration] Contextual launcher tray actions with recent commands
+- [Pack: Collaboration] Inline doc hints and contextual tooltips
+- [Pack: Collaboration] Command palette/quick-action menu in the launcher
+ - [Pack: Collaboration] Canonical admin routes: `/admin/debug`, `/admin/ui/*` (keep clear dev aliases)
+ - [Pack: Collaboration] SSE robustness: status badges + auto-reconnect with backoff and Last-Event-ID resume
+ - [Pack: Collaboration] Connections: per-connection admin token and open app windows for that base
+ - [Pack: Collaboration] Schema-generated forms from OpenAPI for consistent parameter UIs
 
 ## Medium‑Term (3–6 Months)
-- Multi-modal input (voice, stylus, gesture)
-- Predictive autoflow suggestions
-- Progressive disclosure interface pattern
-- Tiled debug surface with rearrangeable panels
-- Live linting for macros and one-click tool sandboxing
-- Integrated monitoring/analytics modules
-- Voice/terminal parity for key commands
+- [Pack: Collaboration] Multi-modal input (voice, stylus, gesture)
+- [Pack: Collaboration] Predictive autoflow suggestions
+- [Pack: Collaboration] Progressive disclosure interface pattern
+- [Pack: Collaboration] Tiled debug surface with rearrangeable panels
+- [Pack: Collaboration] Live linting for macros and one-click tool sandboxing
+- [Pack: Collaboration] Integrated monitoring/analytics modules
+- [Pack: Collaboration] Voice/terminal parity for key commands
 
 ## Long‑Term (6+ Months)
-- Timeline-based activity stream with timeline scrubber
-- Dynamic flow view and declarative recipe builder
-- Real-time collaboration cues and shareable debug sessions
-- Cross-device handoff of in-progress sessions
-- Minimal offline docs packaged with app
-- Inline node graph visualization of agent events
-- Comprehensive debug session export/import
-- Dynamic "what-if" runs branching from historical states
+- [Pack: Collaboration] Timeline-based activity stream with timeline scrubber
+- [Pack: Collaboration] Dynamic flow view and declarative recipe builder
+- [Pack: Collaboration] Real-time collaboration cues and shareable debug sessions
+- [Pack: Collaboration] Cross-device handoff of in-progress sessions
+- [Pack: Collaboration] Minimal offline docs packaged with app
+- [Pack: Collaboration] Inline node graph visualization of agent events
+- [Pack: Collaboration] Comprehensive debug session export/import
+- [Pack: Collaboration] Dynamic "what-if" runs branching from historical states

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,112 +10,124 @@ Type: Reference
 See also: [Backlog](BACKLOG.md) and [Interface Roadmap](INTERFACE_ROADMAP.md).
 Roadmap highlights themes and timelines; Backlog tracks actionable items.
 
-## Recently Shipped (Sep 2025)
-- Stability baseline (v0.1.0-beta): consolidation freeze, clippy-clean core, docs freeze checklist, CHANGELOG + release script.
-- Optional gRPC server for arw-svc (feature-flagged; ARW_GRPC=1).
-- CI hardening: cargo-audit, cargo-deny, CodeQL, Nix build/test, docs link-check (lychee), Windows Pester tests; concurrency cancellation.
-- Containers & Ops: multi-stage Dockerfile (non-root), docker-compose, Helm chart (readiness/liveness, securityContext, optional PVC), Justfile helpers.
-- Dev environment: Nix devshell, VS Code devcontainer.
-- Docs: training research + wiki structure pages; gRPC guide; stability checklist; docgen updates; OpenAPI regeneration in CI.
-- Repo hygiene: Dependabot for Cargo and Actions; .gitattributes for line endings.
-- Persistence hardening: atomic JSON/bytes writes with per‑path async locks; best‑effort cross‑process advisory locks; audit log rotation.
-- Event bus upgrades: counters (published/delivered/lagged/no_receivers), configurable capacity/replay, lag surfaced as `bus.gap`, subscribe‑filtered API, SSE replay and prefix filters, optional persistent JSONL journal with rotation, Prometheus `/metrics`.
-- Debug/Launcher UIs: metrics quick‑link, SSE presets (Replay 50, Models‑only), insights wired to route stats, download progress.
-- Workflow Views: universal right‑sidecar across Hub/Chat/Training with Timeline/Context/Policy/Metrics/Models; command palette; Compare panels (Text/JSON, Image, CSV) in Hub; Chat A/B pin‑to‑compare; Events window presets + filters; Logs focus mode and route filter; P95 sparklines.
-- Episodes & State: live read‑models under `/state/*` (observations, beliefs, world, intents, actions, episodes) with corr_id stitching, duration and error rollups; Episodes panel with filters and details in Debug UI. The `world` view is a scoped belief graph (Project Map) built from the event stream with a selector endpoint for top‑K beliefs.
-- Resources pattern: unified AppState with typed `Resources`; moved Governor/Hierarchy/Memory/Models logic behind services; endpoints prefer services while preserving behavior.
-- Tests + Lint: fixed flaky gating contract tests (serialized shared state); workspace clippy clean with `-D warnings`.
+## Scope Badges
+- `[Kernel]` — Hardening the core runtime (journal, security, orchestration) so the "Collapse the Kernel" thread of the Complexity Collapse initiative stays lean and dependable.
+- `[Pack: Collaboration]` — Optional collaboration and UI packs that sit on top of the kernel; they align with Complexity Collapse goals around a shared sidecar, calm surfaces, and multi-user governance.
+- `[Pack: Research]` — Optional research, experimentation, and memory packs that extend the kernel with advanced retrieval, clustering, or replay capabilities envisioned in Complexity Collapse.
 
-## Near‑Term (Weeks)
-- Kernel & Triad (in progress): unify to a single SQLite journal + CAS, and expose the triad API (`/actions`, `/events`, `/state`). Initial step: kernel journal with DB‑backed replay on `/triad/events` and dual‑write from the in‑process bus.
-- Stabilization window: limit to bug fixes, docs, tests, and internal cleanups; additive API changes only.
-- Observability & Eventing: event journal tail/readers and metrics/docgen polish — see Backlog → Now.
-- Security & Remote Access: hashed tokens, per‑route gating, TLS profiles, proxy templates — see Backlog → Now.
-- UI coherence & routing: canonical admin debug/UI endpoints; launcher open path alignment; SSE reconnection/backoff and status — see Backlog → UI Coherence.
-- Egress Firewall (plan): add policy network scopes + TTL leases; per‑node loopback proxy + DNS guard; route containerized scrapers first; egress ledger and pre‑offload preview; default posture “Public only.”
-- Lightweight mitigations (plan): memory quarantine; project isolation; belief‑diff review queue; hardened headless browsing (disable SW/H3; same‑origin); safe archive jail; DNS guard with anomaly alerts; secrets redaction; security posture presets.
-- Asimov Capsule Guard (plan): lease-based capsules with runtime refresh hooks and telemetry — see Architecture → Asimov Capsule Guard.
-- State & Episodes: observations/beliefs/intents/actions stores; episodes with reactive UI — see Backlog → Now.
-- Services & Orchestration: hierarchy/governor services; queue leases and nack behavior — see Backlog → Now.
-- Specs & Interop: AsyncAPI + MCP artifacts and /spec/* serving — see Backlog → Now.
-- Docs & Showcase: gating keys docgen; packaging and installer polish — see Backlog → Next.
- - Visual capture: screenshot tool (OS‑level) with optional window crop; OCR (optional); SSE events + thumbnails; sidecar Activity integration.
- - UI coherence: universal right‑sidecar across Hub/Chat/Training; command palette
- - Recipes MVP: schema + gallery + runner (local‑first, default‑deny permissions)
- - Logic Units (config‑first): manifest/schema, Library UI with diff preview, apply/revert/promote, initial sample units
- - Research Watcher (read‑only): draft Suggested units from curated feeds; human review flow
+## Kernel Hardening
 
-## Caching & Performance
-- Inference‑level: enable llama.cpp prompt cache; plan vLLM prefix/KV reuse when we add that backend.
-- Exact CAS HTTP caching: strong validators and long‑lived `Cache-Control` for immutable model blobs served by sha256.
-- Action Cache (Bazel‑style): deterministic keys (tool id, version, canonical input, env signature) → CAS’d outputs; in‑memory front (W‑TinyLFU), disk CAS backing.
-- Request coalescing: singleflight on identical tool calls and expensive reads to prevent stampedes.
-- Read‑models over SSE: stream JSON Patch deltas with Last‑Event‑ID resume; avoid snapshot retransmits.
-- Semantic caches (design): per‑user/project Q→A cache with verifier; negative cache for retrieval misses; SimHash prefilter.
-- Storage: RocksDB tiers for persistent caches; optional flash secondary cache; Zstd dictionaries for small JSON blobs.
-- Measurement: layer hit ratios, latency/bytes saved, stampede suppression, semantic false‑hit rate; expose in `/state/*`.
- - Cache Policy: author a declarative cache policy manifest and loader; map to current knobs incrementally; document fallbacks and scope privacy defaults.
+### Recently Shipped (Sep 2025)
+- [Kernel] Stability baseline (v0.1.0-beta): consolidation freeze, clippy-clean core, docs freeze checklist, CHANGELOG + release script.
+- [Kernel] Optional gRPC server for arw-svc (feature-flagged; ARW_GRPC=1).
+- [Kernel] CI hardening: cargo-audit, cargo-deny, CodeQL, Nix build/test, docs link-check (lychee), Windows Pester tests; concurrency cancellation.
+- [Kernel] Containers & Ops: multi-stage Dockerfile (non-root), docker-compose, Helm chart (readiness/liveness, securityContext, optional PVC), Justfile helpers.
+- [Kernel] Dev environment: Nix devshell, VS Code devcontainer.
+- [Kernel] Repo hygiene: Dependabot for Cargo and Actions; .gitattributes for line endings.
+- [Kernel] Persistence hardening: atomic JSON/bytes writes with per-path async locks; best-effort cross-process advisory locks; audit log rotation.
+- [Kernel] Event bus upgrades: counters (published/delivered/lagged/no_receivers), configurable capacity/replay, lag surfaced as `bus.gap`, subscribe-filtered API, SSE replay and prefix filters, optional persistent JSONL journal with rotation, Prometheus `/metrics`.
+- [Kernel] Episodes & State: live read-models under `/state/*` (observations, beliefs, world, intents, actions, episodes) with corr_id stitching, duration and error rollups; Episodes panel with filters and details in Debug UI. The `world` view is a scoped belief graph (Project Map) built from the event stream with a selector endpoint for top-K beliefs.
+- [Kernel] Resources pattern: unified AppState with typed `Resources`; moved Governor/Hierarchy/Memory/Models logic behind services; endpoints prefer services while preserving behavior.
+- [Kernel] Tests + Lint: fixed flaky gating contract tests (serialized shared state); workspace clippy clean with `-D warnings`.
 
-## Heuristic Feedback Engine
-Scope: Lightweight, near‑live suggestions with guardrails.
-See Backlog → Now → Feedback Engine for concrete work items.
+### Near-Term (Weeks)
+- [Kernel] Kernel & Triad (in progress): unify to a single SQLite journal + CAS, and expose the triad API (`/actions`, `/events`, `/state`). Initial step: kernel journal with DB-backed replay on `/triad/events` and dual-write from the in-process bus.
+- [Kernel] Stabilization window: limit to bug fixes, docs, tests, and internal cleanups; additive API changes only.
+- [Kernel] Observability & Eventing: event journal tail/readers and metrics/docgen polish — see Backlog → Now.
+- [Kernel] Security & Remote Access: hashed tokens, per-route gating, TLS profiles, proxy templates — see Backlog → Now.
+- [Kernel] Egress Firewall (plan): add policy network scopes + TTL leases; per-node loopback proxy + DNS guard; route containerized scrapers first; egress ledger and pre-offload preview; default posture “Public only.”
+- [Kernel] Lightweight mitigations (plan): memory quarantine; project isolation; belief-diff review queue; hardened headless browsing (disable SW/H3; same-origin); safe archive jail; DNS guard with anomaly alerts; secrets redaction; security posture presets.
+- [Kernel] Asimov Capsule Guard (plan): lease-based capsules with runtime refresh hooks and telemetry — see Architecture → Asimov Capsule Guard.
+- [Kernel] State & Episodes: observations/beliefs/intents/actions stores; episodes with reactive UI — see Backlog → Now.
+- [Kernel] Services & Orchestration: hierarchy/governor services; queue leases and nack behavior — see Backlog → Now.
+- [Kernel] Specs & Interop: AsyncAPI + MCP artifacts and /spec/* serving — see Backlog → Now.
 
-## Complexity Collapse Initiative
-- Collapse surfaces to one API (`/state`, `/events`, `/actions`), one SQLite journal + content-addressed blobs, one job scheduler, one plugin ABI, and a shared UI sidecar/form builder.
-- Schema-first patches for Project/AgentProfile/Policy/etc. with a documented event taxonomy; flows and errors modeled as data.
-- Unified engines: retrieval pipeline, memory abstraction, runtime/cluster matrix, and capability/lease security.
-- Goal: keep the kernel tiny; push features into declarative packs and reusable executors.
+### Caching & Performance
+- [Kernel] Inference-level: enable llama.cpp prompt cache; plan vLLM prefix/KV reuse when we add that backend.
+- [Kernel] Exact CAS HTTP caching: strong validators and long-lived `Cache-Control` for immutable model blobs served by sha256.
+- [Kernel] Action Cache (Bazel-style): deterministic keys (tool id, version, canonical input, env signature) → CAS’d outputs; in-memory front (W-TinyLFU), disk CAS backing.
+- [Kernel] Request coalescing: singleflight on identical tool calls and expensive reads to prevent stampedes.
+- [Kernel] Read-models over SSE: stream JSON Patch deltas with Last-Event-ID resume; avoid snapshot retransmits.
+- [Kernel] Semantic caches (design): per-user/project Q→A cache with verifier; negative cache for retrieval misses; SimHash prefilter.
+- [Kernel] Storage: RocksDB tiers for persistent caches; optional flash secondary cache; Zstd dictionaries for small JSON blobs.
+- [Kernel] Measurement: layer hit ratios, latency/bytes saved, stampede suppression, semantic false-hit rate; expose in `/state/*`.
+- [Kernel] Cache Policy: author a declarative cache policy manifest and loader; map to current knobs incrementally; document fallbacks and scope privacy defaults.
 
-## Mid‑Term (1–2 Months)
-- UI app to manage various project types.
-- WASI plugin sandbox: capability‑based tools with explicit permissions.
-- Policy engine integration: Cedar bindings; per‑tool permission manifests.
-- Model orchestration: adapters (llama.cpp, ONNX Runtime) with pooling and profiles.
-  - vLLM adapter with PagedAttention and prefix cache; share KV across sessions.
-  - GPU/CPU KV memory policy hints for long‑context batching and prefix sharing.
-- Capsules: record inputs/outputs/events/hints; export/import; deterministic replay.
-- Dataset & memory lab: local pipelines, tags, audits, and reproducible reports.
- - Commons Kit: ship 5 public‑goods recipes with signed index and exportable memories.
- - Logic Units v2: scripted transforms (sandboxed) and plugin units (with contract tests); policy‑gated installation; compatibility matrix
-- Tests: feature‑gated HTTP oneshot tests; policy and capability contract tests.
-- AsyncAPI + MCP artifacts: generate `/spec/asyncapi.yaml` and `/spec/mcp-tools.json` in CI; serve `/spec/*` endpoints.
-- Policy hooks for feedback auto‑apply decisions (shadow mode → guarded auto).
-- Cluster trust (plan): node manifest pinning; mTLS; event sequencing and dedupe keys; scheduler targets only trusted manifests.
-- Regulatory Provenance Unit (RPU): trust store, signature verification, Cedar ABAC for capsule adoption, hop TTL/propagation, adoption ledger (ephemeral by default).
-- JetStream durable queue backend with acks, delay/nack, and subject mapping (keep core NATS for fast lane).
- - Peer/edge CAS: gated `by-digest` endpoints for tool artifacts; optional gossip in multi‑host dev.
-- Remote core connections (secure multi‑node):
-  - mTLS between nodes/connectors and a remote coordinator; certificate rotation strategy.
-  - NATS TLS profiles and client auth options for WAN clusters; local default remains plaintext loopback.
-  - Policy‑gated remote admin surface; proxy headers validation; optional IP allowlists.
-- Budgets/Quotas: optional allow-with-budgets with per-window counters persisted to state; deny precedence.
+### Complexity Collapse Initiative
+- [Kernel] Collapse surfaces to one API (`/state`, `/events`, `/actions`), one SQLite journal + content-addressed blobs, one job scheduler, one plugin ABI, and a shared UI sidecar/form builder.
+- [Kernel] Schema-first patches for Project/AgentProfile/Policy/etc. with a documented event taxonomy; flows and errors modeled as data.
+- [Kernel] Unified engines: retrieval pipeline, memory abstraction, runtime/cluster matrix, and capability/lease security.
+- [Kernel] Goal: keep the kernel tiny; push features into declarative packs and reusable executors.
 
-### Federated Clustering (MVP Path)
-- Remote runner (one extra box): register Worker, accept jobs, stream results; enforce policies/budgets at Home.
-- Cluster Matrix + scheduler: show nodes; route simple offloads (long‑context inference, heavy tools); per‑node queues.
-- Live session sharing: invite guest with roles (view/suggest/drive); staging approvals remain on Home.
-- Egress ledger + previews: show payload summary/cost before offload; record to ledger.
-- Content‑addressed models: Workers announce hashes; Home instructs fetch from allowed peers or registry; verify on load.
-- World diffs: export “public beliefs” with provenance; review conflicts on import.
-- Contribution meter + revenue ledger: track contributions per node; settlement report (CSV) with clear math.
-- Minimal broker (optional): tiny relay/directory for NAT‑tricky cases; stateless/replaceable.
+### Mid-Term (1–2 Months)
+- [Kernel] WASI plugin sandbox: capability-based tools with explicit permissions.
+- [Kernel] Policy engine integration: Cedar bindings; per-tool permission manifests.
+- [Kernel] Model orchestration: adapters (llama.cpp, ONNX Runtime) with pooling and profiles, plus a vLLM adapter with PagedAttention and prefix cache and GPU/CPU KV memory policy hints for long-context batching and prefix sharing.
+- [Kernel] Tests: feature-gated HTTP oneshot tests; policy and capability contract tests.
+- [Kernel] AsyncAPI + MCP artifacts: generate `/spec/asyncapi.yaml` and `/spec/mcp-tools.json` in CI; serve `/spec/*` endpoints.
+- [Kernel] Policy hooks for feedback auto-apply decisions (shadow mode → guarded auto).
+- [Kernel] JetStream durable queue backend with acks, delay/nack, and subject mapping (keep core NATS for fast lane); add peer/edge CAS with gated `by-digest` endpoints for tool artifacts and optional gossip in multi-host dev.
+- [Kernel] Budgets/Quotas: optional allow-with-budgets with per-window counters persisted to state; deny precedence.
 
-## Long‑Term (3–6 Months)
-- Ledger‑driven settlement tooling:
-  - Contribution meter and revenue ledger mature into auditable exports for collaborators.
-  - Opt‑in policy templates help teams review disputes locally without a separate governance simulator.
-- Research‑grade local stack:
-  - On‑device accel (CPU/GPU/NPU), quantization, LoRA fine‑tuning, model manifests.
-  - Artifact signing/verification, SBOMs, and dependency audits.
-  - Signed policy capsules with Sigstore; rely on RPU trust store + local timestamping (renegotiation on restart remains default).
+### Guiding Principles
+- [Kernel] Local-first, open, privacy-respecting, and comprehensible.
+- [Kernel] Calm defaults; explicit opt-in for power features.
+- [Kernel] One truth for schemas & keys (central registry); reproducibility over hype.
 
-## Guiding Principles
-- Local‑first, open, privacy‑respecting, and comprehensible.
-- Calm defaults; explicit opt‑in for power features.
-- One truth for schemas & keys (central registry); reproducibility over hype.
+### MVP Acceptance Checks
+- [Kernel] Logic Units: install/apply/revert with diff preview; events visible; snapshot records active units.
+- [Kernel] Read-models: `/state/logic_units`, `/state/experiments`, `/state/runtime_matrix`, `/state/episode/{id}/snapshot` respond.
+- [Kernel] Evaluation: A/B dry-run flow produces metrics and renders in UI.
+- [Kernel] Policy: permission prompts surface as leases; visible in sidecar and `/state/policy`.
 
-## MVP Acceptance Checks
-- Logic Units: install/apply/revert with diff preview; events visible; snapshot records active units.
-- Read‑models: `/state/logic_units`, `/state/experiments`, `/state/runtime_matrix`, `/state/episode/{id}/snapshot` respond.
-- Evaluation: A/B dry‑run flow produces metrics and renders in UI.
-- Policy: permission prompts surface as leases; visible in sidecar and `/state/policy`.
+## Optional Packs
+
+### Pack: Collaboration
+
+#### Recently Shipped
+- [Pack: Collaboration] Debug/Launcher UIs: metrics quick-link, SSE presets (Replay 50, Models-only), insights wired to route stats, download progress.
+- [Pack: Collaboration] Workflow Views: universal right-sidecar across Hub/Chat/Training with Timeline/Context/Policy/Metrics/Models; command palette; Compare panels (Text/JSON, Image, CSV) in Hub; Chat A/B pin-to-compare; Events window presets + filters; Logs focus mode and route filter; P95 sparklines.
+
+#### Near-Term (Weeks)
+- [Pack: Collaboration] UI coherence & routing: canonical admin debug/UI endpoints; launcher open path alignment; SSE reconnection/backoff and status; universal right-sidecar across Hub/Chat/Training; command palette.
+- [Pack: Collaboration] Docs & Showcase: gating keys docgen; packaging and installer polish — see Backlog → Next.
+- [Pack: Collaboration] Visual capture: screenshot tool (OS-level) with optional window crop; OCR (optional); SSE events + thumbnails; sidecar Activity integration.
+- [Pack: Collaboration] Recipes MVP: schema + gallery + runner (local-first, default-deny permissions).
+- [Pack: Collaboration] Heuristic Feedback Engine: lightweight, near-live suggestions with guardrails — see Backlog → Now → Feedback Engine for concrete work items.
+
+#### Mid-Term (1–2 Months)
+- [Pack: Collaboration] UI app to manage various project types.
+- [Pack: Collaboration] Regulatory Provenance Unit (RPU): trust store, signature verification, Cedar ABAC for capsule adoption, hop TTL/propagation, adoption ledger (ephemeral by default).
+
+#### Long-Term (3–6 Months)
+- [Pack: Collaboration] Ledger-driven settlement tooling: contribution meter and revenue ledger mature into auditable exports for collaborators, and opt-in policy templates help teams review disputes locally without a separate governance simulator.
+
+### Pack: Research
+
+#### Recently Shipped
+- [Pack: Research] Docs: training research + wiki structure pages; gRPC guide; stability checklist; docgen updates; OpenAPI regeneration in CI.
+
+#### Near-Term (Weeks)
+- [Pack: Research] Logic Units (config-first): manifest/schema, Library UI with diff preview, apply/revert/promote, initial sample units.
+- [Pack: Research] Research Watcher (read-only): draft Suggested units from curated feeds; human review flow.
+
+#### Mid-Term (1–2 Months)
+- [Pack: Research] Capsules: record inputs/outputs/events/hints; export/import; deterministic replay.
+- [Pack: Research] Dataset & memory lab: local pipelines, tags, audits, and reproducible reports.
+- [Pack: Research] Commons Kit: ship 5 public-goods recipes with signed index and exportable memories.
+- [Pack: Research] Logic Units v2: scripted transforms (sandboxed) and plugin units (with contract tests); policy-gated installation; compatibility matrix.
+- [Pack: Research] Cluster trust (plan): node manifest pinning; mTLS; event sequencing and dedupe keys; scheduler targets only trusted manifests.
+- [Pack: Research] Remote core connections (secure multi-node): mTLS between nodes/connectors and a remote coordinator with certificate rotation, NATS TLS profiles and client auth options for WAN clusters (local default remains plaintext loopback), policy-gated remote admin surface with proxy headers validation, and optional IP allowlists.
+
+#### Federated Clustering (MVP Path)
+- [Pack: Research] Remote runner (one extra box): register Worker, accept jobs, stream results; enforce policies/budgets at Home.
+- [Pack: Research] Cluster Matrix + scheduler: show nodes; route simple offloads (long-context inference, heavy tools); per-node queues.
+- [Pack: Research] Live session sharing: invite guest with roles (view/suggest/drive); staging approvals remain on Home.
+- [Pack: Research] Egress ledger + previews: show payload summary/cost before offload; record to ledger.
+- [Pack: Research] Content-addressed models: Workers announce hashes; Home instructs fetch from allowed peers or registry; verify on load.
+- [Pack: Research] World diffs: export “public beliefs” with provenance; review conflicts on import.
+- [Pack: Research] Contribution meter + revenue ledger: track contributions per node; settlement report (CSV) with clear math.
+- [Pack: Research] Minimal broker (optional): tiny relay/directory for NAT-tricky cases; stateless/replaceable.
+
+#### Long-Term (3–6 Months)
+- [Pack: Research] Research-grade local stack: on-device accel (CPU/GPU/NPU), quantization, LoRA fine-tuning, model manifests, artifact signing/verification, SBOMs, dependency audits, and signed policy capsules with Sigstore that rely on the RPU trust store plus local timestamping (renegotiation on restart remains default).


### PR DESCRIPTION
## Summary
- add a scope-badge legend and reorganize the roadmap so kernel hardening appears first and optional packs follow
- tag backlog and interface roadmap entries with the same badges to keep planning docs aligned with the roadmap terminology

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68c9f8077c608330b0f82fb037f4a14c