### PR TITLE
Add memory pointer support to context rehydrate

### DIFF
--- a/apps/arw-server/src/util.rs
+++ b/apps/arw-server/src/util.rs
@@ -1,5 +1,4 @@
-use serde_json::json;
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::path::PathBuf;
 
 pub fn default_models() -> Vec<Value> {
@@ -21,4 +20,16 @@ pub fn effective_posture() -> String {
 
 pub fn state_dir() -> PathBuf {
     PathBuf::from(std::env::var("ARW_STATE_DIR").unwrap_or_else(|_| "state".into()))
+}
+
+pub fn attach_memory_ptr(value: &mut Value) {
+    let Some(obj) = value.as_object_mut() else {
+        return;
+    };
+    if obj.contains_key("ptr") {
+        return;
+    }
+    if let Some(id) = obj.get("id").and_then(|v| v.as_str()) {
+        obj.insert("ptr".into(), json!({"kind": "memory", "id": id}));
+    }
 }

--- a/apps/arw-server/src/working_set.rs
+++ b/apps/arw-server/src/working_set.rs
@@ -1,4 +1,4 @@
-use crate::AppState;
+use crate::{util, AppState};
 use anyhow::Result;
 use chrono::SecondsFormat;
 use metrics::{counter, histogram};
@@ -979,7 +979,7 @@ fn build_diagnostics(
 }
 
 impl Candidate {
-    fn from_value(id: String, lane: Option<String>, value: Value, cscore: f32) -> Self {
+    fn from_value(id: String, lane: Option<String>, mut value: Value, cscore: f32) -> Self {
         let key = value
             .get("key")
             .and_then(|v| v.as_str())
@@ -997,6 +997,7 @@ impl Candidate {
             })
             .unwrap_or_default();
         let embed = parse_embed(&value);
+        util::attach_memory_ptr(&mut value);
         Candidate {
             id,
             lane,

--- a/docs/guide/policy_abac.md
+++ b/docs/guide/policy_abac.md
@@ -22,6 +22,7 @@ Set `ARW_POLICY_FILE` to a JSON file:
   "allow_all": false,
   "lease_rules": [
     { "kind_prefix": "net.http.", "capability": "net:http" },
+    { "kind_prefix": "context.rehydrate.memory", "capability": "context:rehydrate:memory" },
     { "kind_prefix": "context.rehydrate", "capability": "context:rehydrate:file" },
     { "kind_prefix": "fs.", "capability": "fs" },
     { "kind_prefix": "app.vscode.", "capability": "io:app:vscode" }
@@ -41,7 +42,7 @@ Presets
 
 ## Server Integration
 - `POST /actions`: evaluates policy for the action kind. If a capability is required, verifies a valid lease for subject `local`.
-- `POST /context/rehydrate`: when policy says context rehydrate requires a lease, checks for `context:rehydrate:file` or a generic `fs` lease.
+- `POST /context/rehydrate`: when policy says context rehydrate requires a lease, checks for `context:rehydrate:memory` (memory pointers), `context:rehydrate:file`, or a generic `fs` lease.
 - `GET /state/policy`: returns the current policy snapshot (from `ARW_POLICY_FILE` or defaults).
 - `fs.patch` action: lease‑gated when `fs.*` requires a capability; writes atomically under `state/projects` and emits `projects.file.written`.
  - `app.vscode.open` action: lease‑gated when `app.vscode.*` requires a capability; spawns VS Code to open a path under `state/projects`; emits `apps.vscode.opened`.

--- a/docs/reference/feature_catalog.md
+++ b/docs/reference/feature_catalog.md
@@ -26,7 +26,7 @@ _Spin up projects with live state, context-on-demand, and predictable response t
   _Source_: [apps/arw-server/src/main.rs](https://github.com/t3hw00t/ARW/blob/main/apps/arw-server/src/main.rs), [apps/arw-server/src/api_actions.rs](https://github.com/t3hw00t/ARW/blob/main/apps/arw-server/src/api_actions.rs), [apps/arw-server/src/api_events.rs](https://github.com/t3hw00t/ARW/blob/main/apps/arw-server/src/api_events.rs), …
 
 - **Working Set Builder** · backend / builder / intelligence / beta
-  Hybrid retrieval with coverage loops, streaming diagnostics, and on-demand rehydrate for just-in-time context.
+  Hybrid retrieval with coverage loops, streaming diagnostics, and on-demand rehydrate for just-in-time context (stable pointers include `memory` ids and `file` heads).
   _Routes_: `POST /context/assemble`, `POST /context/rehydrate`
   _Signals_: `working_set.started`, `working_set.seed`, `working_set.expanded`, `working_set.expand_query`, `working_set.selected`, `working_set.completed`, `working_set.iteration.summary`, `working_set.error`
   _Env_: `ARW_CONTEXT_LANES_DEFAULT`, `ARW_CONTEXT_K`, `ARW_CONTEXT_EXPAND_PER_SEED`, `ARW_CONTEXT_DIVERSITY_LAMBDA`, `ARW_CONTEXT_MIN_SCORE`, `ARW_CONTEXT_LANE_BONUS`, `ARW_CONTEXT_EXPAND_QUERY`, `ARW_CONTEXT_EXPAND_QUERY_TOP_K`, …
@@ -70,7 +70,7 @@ Every answer carries provenance, memory, and opportunities to improve.
 _Surface the beliefs, files, and links that back each decision._
 
 - **Memory Atlas** · backend / builder / intelligence / beta
-  Kernel-backed memory API with hybrid search, embeddings, and coherent selections for durable knowledge.
+  Kernel-backed memory API with hybrid search, embeddings, coherent selections, and stable pointers (`ptr.kind: "memory"`) for durable knowledge.
   _Routes_: `POST /memory/put`, `GET /state/memory/select`, `POST /memory/search_embed`, `POST /state/memory/select_hybrid`, `POST /memory/select_coherent`, `POST /state/memory/explain_coherent`, `GET /state/memory/recent`, `POST /memory/link`, `GET /state/memory/links`
   _Signals_: `memory.record.put`, `memory.link.put`
   _Source_: [apps/arw-server/src/api_memory.rs](https://github.com/t3hw00t/ARW/blob/main/apps/arw-server/src/api_memory.rs), [crates/arw-kernel/src/lib.rs](https://github.com/t3hw00t/ARW/blob/main/crates/arw-kernel/src/lib.rs)


### PR DESCRIPTION
## Summary
- allow /context/rehydrate to service `memory` pointers with policy/lease enforcement
- add shared helper to attach memory pointers to API responses and working set outputs
- document the new memory pointer flow and policy options across restructure and policy guides

## Testing
- cargo test -p arw-server

------
https://chatgpt.com/codex/tasks/task_e_68ca0e186db08330a40e2a4117df9b82