### PR TITLE
docs: refresh unified port references

### DIFF
--- a/docs/API_AND_SCHEMA.md
+++ b/docs/API_AND_SCHEMA.md
@@ -14,7 +14,7 @@ Explore the API
 Set a base URL and (optionally) an admin token for gated endpoints.
 
 ```bash
-export BASE=http://127.0.0.1:8090
+export BASE=http://127.0.0.1:8091
 export ARW_ADMIN_TOKEN=secret   # if set on the server
 H() { curl -sS -H "X-ARW-Admin: $ARW_ADMIN_TOKEN" "$@"; }
 ```

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -12,7 +12,7 @@ See also: [Glossary](GLOSSARY.md), [Admin Endpoints](guide/admin_endpoints.md), 
 Centralized reference for ARW environment variables and common flags. Defaults favor local, private, and portable operation.
 
 ## Service
-- `ARW_PORT`: HTTP listen port (default: `8090`).
+- `ARW_PORT`: HTTP listen port (default: `8091`; legacy `arw-svc` listens on `8090`).
 - `ARW_BIND`: HTTP bind address (default: `127.0.0.1`). Use `0.0.0.0` to listen on all interfaces in trusted environments or behind a TLS proxy.
 - `ARW_PORTABLE`: `1` keeps state/cache/logs near the app bundle.
  - `ARW_CONFIG`: absolute path to the primary config TOML (overrides discovery).

--- a/docs/developer/windows-start-validation.md
+++ b/docs/developer/windows-start-validation.md
@@ -6,6 +6,10 @@ title: Windows Start Script Validation
 
 This checklist helps validate ARW startup on Windows after changes to `scripts/start.ps1` and the interactive menus.
 
+!!! note "Legacy launcher path"
+    The interactive launcher workflow still boots the legacy `arw-svc` bridge on port 8090. For the headless unified `arw-server`
+    default (port 8091), follow the server-specific docs.
+
 Updated: 2025-09-16
 Type: Reference
 

--- a/docs/guide/METRICS_AND_INSIGHTS.md
+++ b/docs/guide/METRICS_AND_INSIGHTS.md
@@ -87,7 +87,7 @@ Example scrape minimal config (Prometheus):
 scrape_configs:
   - job_name: 'arw'
     static_configs:
-      - targets: ['127.0.0.1:8090']
+      - targets: ['127.0.0.1:8091']
         labels:
           instance: 'local'
     metrics_path: /metrics

--- a/docs/guide/admin_endpoints.md
+++ b/docs/guide/admin_endpoints.md
@@ -15,13 +15,15 @@ Type: How‑to
 - Index (JSON): `/admin/index.json`
 - Public endpoints (no auth): `/healthz`, `/metrics`, `/spec/*`, `/version`, `/about`
 
+Unless noted, examples assume the unified `arw-server` on `http://127.0.0.1:8091`. Use port `8090` when interacting with the legacy `arw-svc` bridge.
+
 ### Public: /about
 - Path: `GET /about`
 - Returns a small JSON document with service + branding info and a live endpoint index:
   - `name`: "Agent Hub (ARW)"
   - `tagline`: "Your private AI control room that can scale and share when you choose."
   - `description`: one‑paragraph plain‑terms summary
-  - `service`: binary id (e.g., `arw-svc`)
+  - `service`: binary id (e.g., `arw-server`)
   - `version`: semantic version string
   - `role`: current node role
   - `docs_url`: base docs URL if configured
@@ -37,7 +39,7 @@ Example
   "name": "Agent Hub (ARW)",
   "tagline": "Your private AI control room that can scale and share when you choose.",
   "description": "Agent Hub (ARW) lets you run your own team of AI helpers on your computer to research, plan, write, and build—while you stay in charge.",
-  "service": "arw-svc",
+  "service": "arw-server",
   "version": "0.1.0",
   "role": "Home",
   "docs_url": "https://t3hw00t.github.io/ARW/",
@@ -161,7 +163,7 @@ Setup:
 
 ```bash
 export ARW_ADMIN_TOKEN=secret123
-BASE=http://127.0.0.1:8090
+BASE=http://127.0.0.1:8091  # legacy bridge listens on 8090
 AH() { curl -sS -H "X-ARW-Admin: $ARW_ADMIN_TOKEN" "$@"; }
 ```
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -8,6 +8,8 @@ Type: How‑to
 
 Goal-oriented tasks using the `arw-cli` binary. This guide shows common commands with copy‑pasteable examples and flags you’re likely to want.
 
+Examples assume the unified `arw-server` is running on `http://127.0.0.1:8091`. Use port `8090` if you are targeting the legacy `arw-svc` bridge.
+
 Prereqs
 - Build or install the workspace: `cargo build -p arw-cli --release`
 - Ensure the service is built if you plan to interact with it, but most CLI commands are local utilities and do not require the service.
@@ -16,7 +18,7 @@ Basics
 - Version and bootstrap
   - `arw-cli` — prints version, calls hello, and shows effective paths
 - Ping
-  - `arw-cli ping --base http://127.0.0.1:8090` — checks `/healthz` and `/about` and prints a JSON summary; `--admin-token` flag or `ARW_ADMIN_TOKEN` env adds Bearer
+  - `arw-cli ping --base http://127.0.0.1:8091` — checks `/healthz` and `/about` and prints a JSON summary; `--admin-token` flag or `ARW_ADMIN_TOKEN` env adds Bearer
 - Paths
   - `arw-cli paths` — JSON of effective `stateDir/cacheDir/logsDir` etc.
   - `arw-cli paths --pretty` — pretty‑printed JSON
@@ -25,11 +27,11 @@ Basics
   - `arw-cli tools --pretty` — pretty JSON
  
 Specs
-- `arw-cli spec health --base http://127.0.0.1:8090 [--pretty]` — fetch `/spec/health` and print JSON (pretty‑print with `--pretty`)
+- `arw-cli spec health --base http://127.0.0.1:8091 [--pretty]` — fetch `/spec/health` and print JSON (pretty‑print with `--pretty`)
 
 Events (SSE)
 - Tail live events from the service with optional replay and prefix filters:
-  - `arw-cli events tail --base http://127.0.0.1:8090 --replay 10 --prefix models. --prefix feedback.`
+  - `arw-cli events tail --base http://127.0.0.1:8091 --replay 10 --prefix models. --prefix feedback.`
   - Add `--json-only` to print only the JSON payloads.
 
 Gating Keys

--- a/docs/guide/compatibility.md
+++ b/docs/guide/compatibility.md
@@ -39,8 +39,9 @@ problems.
 ## Containers and Cloud
 
 - Service in containers
-  - `arw-svc` runs fine in Docker/Podman containers; expose the HTTP port
-    (default 8090). Example: `docker run -p 8090:8090 arw-svc:dev`.
+  - `arw-server` runs fine in Docker/Podman containers; expose the HTTP port
+    (default 8091). Example: `docker run -p 8091:8091 arw-server:dev`.
+    Use port 8090 only when running the legacy `arw-svc` image for the classic debug UI.
   - Desktop Launcher is not intended for headless containers; use a host
     desktop environment or run the Launcher outside the container.
   - GPU access in containers requires host support and appropriate device

--- a/docs/guide/events_sse.md
+++ b/docs/guide/events_sse.md
@@ -52,21 +52,28 @@ Envelope
 - Legacy svc honors `Last-Event-ID` and supports `?replay=N`.
 
 Examples
-- Basic subscription (Unix):
+- Basic subscription (unified server):
   ```bash
-  curl -N http://127.0.0.1:8090/admin/events
+  curl -N http://127.0.0.1:8091/events
   ```
 - With admin token and filter:
   ```bash
   curl -N \
     -H "Authorization: Bearer $ARW_ADMIN_TOKEN" \
-    "http://127.0.0.1:8090/admin/events?prefix=models.&replay=10"
+    "http://127.0.0.1:8091/events?prefix=models.&replay=10"
   ```
   Watch only RPU trust events:
   ```bash
   curl -N \
     -H "Authorization: Bearer $ARW_ADMIN_TOKEN" \
-    "http://127.0.0.1:8090/admin/events?prefix=rpu.&replay=5"
+    "http://127.0.0.1:8091/events?prefix=rpu.&replay=5"
+  ```
+- Legacy bridge (`arw-svc` on 8090):
+  ```bash
+  curl -N http://127.0.0.1:8090/admin/events
+  curl -N \
+    -H "X-ARW-Admin: $ARW_ADMIN_TOKEN" \
+    "http://127.0.0.1:8090/admin/events?prefix=models.&replay=10"
   ```
 
 Event model

--- a/docs/guide/flows.md
+++ b/docs/guide/flows.md
@@ -14,6 +14,9 @@ Type: How‑to
 - Set `ARW_DEBUG=1`
 - Open: `http://127.0.0.1:8090/ui/flows` (or `/admin/ui/flows` with an admin token). In the unified server, planned endpoints live under `/logic-units/*`.
 
+!!! note "Legacy debug UI"
+    The `/ui/flows` surface lives in the legacy `arw-svc` bridge on port 8090. The unified headless server on port 8091 exposes the underlying APIs under `/logic-units/*` instead.
+
 ## What It Does
 
 - Lets you set a Unit ID and optional scope and paste a JSON array of patches

--- a/docs/guide/grpc.md
+++ b/docs/guide/grpc.md
@@ -15,7 +15,7 @@ ARW exposes an optional gRPC server in `arw-svc` behind the `grpc` feature.
   - Default: `[::1]:50051`
   - Override: `ARW_GRPC_ADDR=0.0.0.0:50051`
 
-The HTTP service remains available on `ARW_PORT` (default 8090).
+The HTTP service remains available on `ARW_PORT` (default 8091; legacy `arw-svc` uses 8090).
 
 ## Health example
 

--- a/docs/guide/guardrails.md
+++ b/docs/guide/guardrails.md
@@ -37,7 +37,7 @@ When `ARW_GUARDRAILS_URL` is set, the tool first POSTs `{ text, policy?, rules? 
 ## Example
 
 ```bash
-curl -sS localhost:8090/admin/tools/run \
+curl -sS localhost:8091/admin/tools/run \
   -H 'X-ARW-Admin: $ARW_ADMIN_TOKEN' \
   -H 'content-type: application/json' \
   -d '{

--- a/docs/guide/kubernetes.md
+++ b/docs/guide/kubernetes.md
@@ -9,6 +9,10 @@ Type: How‑to
 
 Deploy the ARW service on Kubernetes using the provided Helm chart.
 
+!!! note "Legacy image"
+    The current Helm chart packages the legacy `arw-svc` bridge (port 8090) so that the classic debug UI and launcher workflows
+    keep working. Use the container instructions under `guide/docker.md` for the headless unified `arw-server` on port 8091.
+
 ## Prerequisites
 - Kubernetes cluster with an ingress controller (optional)
 - Helm 3

--- a/docs/guide/models_download.md
+++ b/docs/guide/models_download.md
@@ -104,7 +104,7 @@ UI guidance:
 
 Minimal SSE consumer (bash)
 ```bash
-BASE=http://127.0.0.1:8090
+BASE=http://127.0.0.1:8091  # use 8090 for the legacy bridge
 curl -N -H "X-ARW-Admin: $ARW_ADMIN_TOKEN" "$BASE/admin/events?prefix=models.download.progress&replay=5" \
  | jq -rc 'if .id then {id:.id,status:(.status//""),code:(.code//""),pct:(.progress//null),dl:(.downloaded//null),tot:(.total//null)} else . end'
 ```
@@ -142,7 +142,7 @@ The downloader maintains a lightweight throughput EWMA used for admission checks
 Start a download (with checksum):
 
 ```bash
-BASE=http://127.0.0.1:8090
+BASE=http://127.0.0.1:8091  # use 8090 for the legacy bridge
 curl -sS -X POST "$BASE/admin/models/download" \
   -H 'Content-Type: application/json' \
   -H "X-ARW-Admin: $ARW_ADMIN_TOKEN" \

--- a/docs/guide/projects_ui.md
+++ b/docs/guide/projects_ui.md
@@ -27,6 +27,9 @@ See also: [Keyboard Shortcuts](shortcuts.md)
 - Start `arw-svc` and open:
   - `http://127.0.0.1:8090/admin/ui/projects`
 
+!!! note "Legacy debug UI"
+    Projects UI is part of the legacy `arw-svc` bridge on port 8090. The unified headless server on port 8091 exposes project APIs under `/projects/*` without this UI shell.
+
 All `/projects/*` endpoints are treated as administrative and are protected by the service’s admin gate.
 
 ## Storage

--- a/docs/guide/reverse_proxy.md
+++ b/docs/guide/reverse_proxy.md
@@ -7,7 +7,7 @@ title: Reverse Proxy (Caddy/Traefik)
 Updated: 2025-09-16
 Type: How‑to
 
-Terminate TLS and proxy to ARW running on `127.0.0.1:8090` or in Docker.
+Terminate TLS and proxy to ARW running on `127.0.0.1:8091` (unified server). Legacy `arw-svc` bridge examples (port `8090`) are noted separately when the classic debug UI is required.
 
 ## Caddy
 
@@ -16,7 +16,7 @@ Terminate TLS and proxy to ARW running on `127.0.0.1:8090` or in Docker.
 ```
 arw.example.com {
   encode zstd gzip
-  reverse_proxy 127.0.0.1:8090
+  reverse_proxy 127.0.0.1:8091
 }
 ```
 
@@ -30,12 +30,11 @@ Docker (compose snippet):
 
 ```yaml
 services:
-  arw-svc:
-    image: ghcr.io/<owner>/arw-svc:latest
+  arw-server:
+    image: ghcr.io/<owner>/arw-server:latest
     environment:
       - ARW_BIND=0.0.0.0
-      - ARW_PORT=8090
-      - ARW_DEBUG=0
+      - ARW_PORT=8091
       - ARW_ADMIN_TOKEN=your-secret
       - ARW_TRUST_FORWARD_HEADERS=1
     networks: [web]
@@ -70,19 +69,18 @@ http:
     arw:
       loadBalancer:
         servers:
-          - url: "http://127.0.0.1:8090"
+          - url: "http://127.0.0.1:8091"
 ```
 
 Docker labels example:
 
 ```yaml
 services:
-  arw-svc:
-    image: ghcr.io/<owner>/arw-svc:latest
+  arw-server:
+    image: ghcr.io/<owner>/arw-server:latest
     environment:
       - ARW_BIND=0.0.0.0
-      - ARW_PORT=8090
-      - ARW_DEBUG=0
+      - ARW_PORT=8091
       - ARW_ADMIN_TOKEN=your-secret
       - ARW_TRUST_FORWARD_HEADERS=1
     labels:
@@ -90,7 +88,7 @@ services:
       - "traefik.http.routers.arw.rule=Host(`arw.example.com`)"
       - "traefik.http.routers.arw.entrypoints=websecure"
       - "traefik.http.routers.arw.tls=true"
-      - "traefik.http.services.arw.loadbalancer.server.port=8090"
+      - "traefik.http.services.arw.loadbalancer.server.port=8091"
 ```
 
 ## Security Notes

--- a/docs/guide/security_hardening.md
+++ b/docs/guide/security_hardening.md
@@ -34,7 +34,7 @@ Capsules & Trust (RPU)
 - Env override: `ARW_TRUST_CAPSULES=/path/to/trust_capsules.json`.
 
 Reverse Proxy
-- Terminate TLS and IP‑restrict at your proxy (Nginx, Caddy, Traefik) and forward to `127.0.0.1:8090`.
+- Terminate TLS and IP‑restrict at your proxy (Nginx, Caddy, Traefik) and forward to `127.0.0.1:8091` (unified server). Use port `8090` only when running the legacy `arw-svc` bridge for the classic debug UI.
 - Set `ARW_DOCS_URL=https://your-domain/docs` so the debug UI can link to your public docs.
 - Keep CORS strict; only enable `ARW_CORS_ANY=1` in development.
 
@@ -52,7 +52,7 @@ server {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_pass http://127.0.0.1:8090;
+    proxy_pass http://127.0.0.1:8091;
   }
 
   # (optional) restrict admin endpoints by path or IP here as a second guard
@@ -63,7 +63,7 @@ Caddy example
 ```
 your-domain {
   encode zstd gzip
-  reverse_proxy 127.0.0.1:8090
+  reverse_proxy 127.0.0.1:8091
   @admin {
     path /admin/debug* /admin/memory* /admin/models* /admin/governor* /admin/introspect* /admin/feedback* /admin/events* /admin/emit* /admin/shutdown
   }
@@ -84,13 +84,13 @@ Description=ARW local service
 After=network.target
 
 [Service]
-Environment=ARW_PORT=8090
+Environment=ARW_PORT=8091
 Environment=ARW_DEBUG=0
 Environment=ARW_ADMIN_TOKEN=change-me
 Environment=ARW_HTTP_TIMEOUT_SECS=20
 Environment=ARW_DOCS_URL=https://your-domain/docs
 WorkingDirectory=%h/ARW
-ExecStart=%h/ARW/target/release/arw-svc
+ExecStart=%h/ARW/target/release/arw-server
 Restart=on-failure
 RestartSec=2s
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -87,7 +87,7 @@ Hung/idle
 Free space via CAS GC
 - Run a one‑off GC to delete unreferenced blobs older than 14 days:
   ```bash
-  BASE=http://127.0.0.1:8090
+  BASE=http://127.0.0.1:8091  # legacy bridge listens on 8090
   curl -sS -X POST "$BASE/admin/models/cas_gc" \
     -H 'Content-Type: application/json' \
     -H "X-ARW-Admin: $ARW_ADMIN_TOKEN" \

--- a/docs/guide/windows_install.md
+++ b/docs/guide/windows_install.md
@@ -62,6 +62,6 @@ Uninstall
 - Developer build: remove `target/` outputs; no registry/service entries are created.
 
 Troubleshooting
-- Health: `http://127.0.0.1:8090/healthz`
+- Health: `http://127.0.0.1:8091/healthz` (legacy bridge listens on 8090)
 - Logs: `.arw\logs\arw-svc.out.log`
 - Interactive start menu: `scripts\interactive-start-windows.ps1`

--- a/docs/ops/systemd_service.md
+++ b/docs/ops/systemd_service.md
@@ -9,6 +9,10 @@ Type: How‑to
 
 Run ARW as a user service, either natively or via Docker.
 
+!!! note "Legacy service"
+    This guide targets the legacy `arw-svc` bridge, which listens on port 8090 and serves the classic debug UI. For the unified
+    headless `arw-server` (default port 8091), use the Docker or service deployment docs under `guide/`.
+
 ## Environment file
 
 `/etc/default/arw-svc` (root) or `~/.config/arw-svc.env` (adjust `EnvironmentFile` accordingly):

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -72,15 +72,15 @@ Examples
 
 ```bash
 # Full download
-curl -SsfLO "http://127.0.0.1:8090/models/blob/0123abcd..."
+curl -SsfLO "http://127.0.0.1:8091/models/blob/0123abcd..."
 
 # Conditional
 curl -I -H 'If-None-Match: "0123abcd..."' \
-  "http://127.0.0.1:8090/models/blob/0123abcd..."
+  "http://127.0.0.1:8091/models/blob/0123abcd..."
 
 # Partial
 curl -sS -H 'Range: bytes=0-1048575' \
-  -o part.bin "http://127.0.0.1:8090/models/blob/0123abcd..."
+  -o part.bin "http://127.0.0.1:8091/models/blob/0123abcd..."
 ```
 - Concurrency (admin):
   - `POST /admin/models/concurrency` — Set max concurrency at runtime; response includes `pending_shrink` when non‑blocking shrink leaves a remainder.

--- a/docs/snippets/http_caching_semantics.md
+++ b/docs/snippets/http_caching_semantics.md
@@ -32,9 +32,9 @@ Examples:
 # HEAD with ETag validator; 304 if unchanged
 curl -I \
   -H 'If-None-Match: "<sha256>"' \
-  http://localhost:8090/admin/models/by-hash/<sha256>
+  http://localhost:8091/admin/models/by-hash/<sha256>
 
 # GET a slice (first 1KB)
 curl -H 'Range: bytes=0-1023' \
-  http://localhost:8090/admin/models/by-hash/<sha256>
+  http://localhost:8091/admin/models/by-hash/<sha256>
 ```


### PR DESCRIPTION
## Summary
- note the unified `arw-server` default port as 8091 in the configuration reference and entry-point snippets
- update CLI/API docs, SSE examples, and download/metrics guides to point at 8091 while clarifying legacy 8090 usage
- tag legacy-only deployment guides (systemd, Helm, debug UIs) and adjust reverse proxy/security guidance for the new default

## Testing
- `bash scripts/docs_check.sh` *(warns when mkdocs is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68ca12d774a083309b0a75dbf733a06d