### PR TITLE
Update flows guide for unified server routes

### DIFF
--- a/docs/guide/flows.md
+++ b/docs/guide/flows.md
@@ -12,12 +12,13 @@ Type: How‑to
 ## Open the Page
 
 - Set `ARW_DEBUG=1`
-- Open: `http://127.0.0.1:8090/ui/flows` (or `/admin/ui/flows` with an admin token). In the unified server, planned endpoints live under `/logic-units/*`.
+- Unified server (default local dev port `http://127.0.0.1:8091`): open `http://127.0.0.1:8091/ui/flows` (or `/admin/ui/flows` with an admin token).
+- Legacy standalone UI builds still serve the page on `http://127.0.0.1:8090/ui/flows`; use that port only when running the split UI stack.
 
 ## What It Does
 
 - Lets you set a Unit ID and optional scope and paste a JSON array of patches
-- Dry‑run or Apply via `POST /admin/logic-units/apply`
+- Dry‑run or Apply via `POST /logic-units/apply`
 - Shows the result payload for quick iteration
 
 ## Patch Example
@@ -36,10 +37,10 @@ This updates planner/governor hints to favor a verified mode with stronger retri
 
 ## Programmatic Use
 
-You can call Logic Units endpoints directly from clients:
+You can call the shipped Logic Units endpoints directly from clients:
 
-- `POST /admin/logic-units/apply` — apply patches
-- `POST /admin/logic-units/install` — register a unit manifest
-- `POST /admin/logic-units/revert` — revert by snapshot id
+- `POST /logic-units/apply` — apply patches
+- `POST /logic-units/install` — register a unit manifest
+- `POST /logic-units/revert` — revert by snapshot id
 
 See also: Guide → Logic Units Library; Architecture → Config Patch Engine.


### PR DESCRIPTION
## Summary
- point the flows page instructions at the unified server default on port 8091 and note when legacy 8090 builds apply
- update the programmatic examples to the current /logic-units apply/install/revert routes that ship with the server

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68ca142d58ec8330982de6617764b516