### PR TITLE
docs: refresh container compatibility guidance

### DIFF
--- a/docs/guide/compatibility.md
+++ b/docs/guide/compatibility.md
@@ -39,8 +39,16 @@ problems.
 ## Containers and Cloud
 
 - Service in containers
-  - `arw-svc` runs fine in Docker/Podman containers; expose the HTTP port
-    (default 8090). Example: `docker run -p 8090:8090 arw-svc:dev`.
+  - Default deployment: use the unified `arw-server` image
+    (`ghcr.io/<owner>/arw-server`). It binds to port 8091; publish it with a
+    command such as `docker run -p 8091:8091 ghcr.io/<owner>/arw-server:latest`
+    (set `ARW_BIND=0.0.0.0` or `ARW_PORT=8091` as needed for your environment).
+  - Legacy UI bridge:
+    - The compatibility `arw-svc` image (`ghcr.io/<owner>/arw-svc`) remains
+      available for the classic debug UI/launcher stack. It binds to 8090 and is
+      maintained for legacy workflows only; see the [Docker guide’s legacy UI
+      bridge section](./docker.md#local-build--run-legacy-ui-bridge) for usage
+      details.
   - Desktop Launcher is not intended for headless containers; use a host
     desktop environment or run the Launcher outside the container.
   - GPU access in containers requires host support and appropriate device


### PR DESCRIPTION
## Summary
- highlight the unified `arw-server` image and its 8091 binding as the default container deployment
- add a legacy `arw-svc` subsection that directs readers to the Docker guide's UI bridge instructions
- update port references in the compatibility guide to distinguish legacy 8090 usage from the 8091 default

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68ca151096808330afdbc63e02df9beb