### PR TITLE
Update AI assistant index for unified server quickstart

### DIFF
--- a/docs/ai/ai_index.md
+++ b/docs/ai/ai_index.md
@@ -4,10 +4,11 @@ Type: Reference
 
 Microsummary: Map of repo for AI/code models: purpose, key files, how to run, limits. Stable entrypoint for tooling.
 
-- Purpose: local‑first agents service (`arw-svc`) with Debug UI, CLI, and recipes.
-- Quick run: see `README.md` → Try in 2 Minutes; docs at `/` and `/debug` once running.
+- Purpose: unified local-first agents service (`arw-server` in `apps/arw-server/`) plus tooling surfaces; legacy `arw-svc` stays available for the classic debug UI during the restructure.
+- Quick run: follow `docs/guide/quickstart.md` for the unified flow; add `--legacy` only when you need the old debug UI bridge.
 - Key files:
-  - Service: `apps/arw-svc/` (Rust); CLI: `apps/arw-cli/`; desktop launcher: `apps/arw-launcher/`.
+  - Primary service: `apps/arw-server/` (Rust unified server). Legacy debug stack: `apps/arw-svc/` (maintenance mode).
+  - CLI: `apps/arw-cli/`; desktop launcher: `apps/arw-launcher/` (currently defaults to legacy until porting completes).
   - Docs: `docs/` (MkDocs Material); site config: `mkdocs.yml`.
   - Schemas: `spec/schemas/`; OpenAPI preview: `docs/static/openapi.json`.
 - Limits: default‑deny for write/shell/network; assume no internet; prefer explicit permissions.


### PR DESCRIPTION
## Summary
- point the AI assistants index at the unified `arw-server` as the primary service and note the legacy `arw-svc`
- update quick run guidance to reference the unified quickstart and reflect restructure status for tooling surfaces

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68ca15163c5c8330b4f02f2d4f41cb02