### PR TITLE
Update reverse proxy guide for unified server and legacy bridge

### DIFF
--- a/docs/guide/reverse_proxy.md
+++ b/docs/guide/reverse_proxy.md
@@ -7,16 +7,18 @@ title: Reverse Proxy (Caddy/Traefik)
 Updated: 2025-09-16
 Type: How‑to
 
-Terminate TLS and proxy to ARW running on `127.0.0.1:8090` or in Docker.
+Terminate TLS and proxy to ARW running on `127.0.0.1:8091` (unified `arw-server`) or via Docker.
 
 ## Caddy
+
+Unified server (`arw-server`) on port 8091:
 
 `Caddyfile`:
 
 ```
 arw.example.com {
   encode zstd gzip
-  reverse_proxy 127.0.0.1:8090
+  reverse_proxy 127.0.0.1:8091
 }
 ```
 
@@ -30,11 +32,11 @@ Docker (compose snippet):
 
 ```yaml
 services:
-  arw-svc:
-    image: ghcr.io/<owner>/arw-svc:latest
+  arw-server:
+    image: ghcr.io/<owner>/arw-server:latest
     environment:
       - ARW_BIND=0.0.0.0
-      - ARW_PORT=8090
+      - ARW_PORT=8091
       - ARW_DEBUG=0
       - ARW_ADMIN_TOKEN=your-secret
       - ARW_TRUST_FORWARD_HEADERS=1
@@ -70,6 +72,88 @@ http:
     arw:
       loadBalancer:
         servers:
+          - url: "http://127.0.0.1:8091"
+```
+
+Docker labels example:
+
+```yaml
+services:
+  arw-server:
+    image: ghcr.io/<owner>/arw-server:latest
+    environment:
+      - ARW_BIND=0.0.0.0
+      - ARW_PORT=8091
+      - ARW_DEBUG=0
+      - ARW_ADMIN_TOKEN=your-secret
+      - ARW_TRUST_FORWARD_HEADERS=1
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.arw.rule=Host(`arw.example.com`)"
+      - "traefik.http.routers.arw.entrypoints=websecure"
+      - "traefik.http.routers.arw.tls=true"
+      - "traefik.http.services.arw.loadbalancer.server.port=8091"
+```
+
+## Legacy UI Bridge (`arw-svc`)
+
+Need the legacy debug UI or launcher bundle? Run the optional bridge on port 8090 instead of the unified server.
+
+### Caddy (Legacy Bridge)
+
+`Caddyfile`:
+
+```
+arw.example.com {
+  encode zstd gzip
+  reverse_proxy 127.0.0.1:8090
+}
+```
+
+Docker (compose snippet):
+
+```yaml
+services:
+  arw-svc:
+    image: ghcr.io/<owner>/arw-svc:latest
+    environment:
+      - ARW_BIND=0.0.0.0
+      - ARW_PORT=8090
+      - ARW_DEBUG=1
+      - ARW_ADMIN_TOKEN=your-secret
+      - ARW_TRUST_FORWARD_HEADERS=1
+    networks: [web]
+  caddy:
+    image: caddy:2
+    ports: ["80:80", "443:443"]
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    networks: [web]
+volumes:
+  caddy-data: {}
+  caddy-config: {}
+networks:
+  web: {}
+```
+
+### Traefik (Legacy Bridge)
+
+Static config (file provider example):
+
+```yaml
+http:
+  routers:
+    arw:
+      rule: Host(`arw.example.com`)
+      service: arw
+      entryPoints: [ websecure ]
+      tls: {}
+  services:
+    arw:
+      loadBalancer:
+        servers:
           - url: "http://127.0.0.1:8090"
 ```
 
@@ -82,7 +166,7 @@ services:
     environment:
       - ARW_BIND=0.0.0.0
       - ARW_PORT=8090
-      - ARW_DEBUG=0
+      - ARW_DEBUG=1
       - ARW_ADMIN_TOKEN=your-secret
       - ARW_TRUST_FORWARD_HEADERS=1
     labels:
@@ -94,5 +178,7 @@ services:
 ```
 
 ## Security Notes
-- Keep `ARW_DEBUG=0` behind proxies; require strong `ARW_ADMIN_TOKEN` for `/admin/*`.
+- Keep `ARW_DEBUG=0` for the unified server and require a strong `ARW_ADMIN_TOKEN`.
+- Protect `/events`, `/actions`, and `/state/*` behind authentication and allowlists when exposing them through the proxy; `/events` streams live telemetry.
 - Add rate‑limiting and IP allowlists at the proxy where possible.
+- Legacy `/admin/*` endpoints only exist when running the optional UI bridge. Harden them per [Legacy UI Bridge (`arw-svc`)](#legacy-ui-bridge-arw-svc) and expose them only when required.


### PR DESCRIPTION
## Summary
- default the reverse proxy examples to the unified `arw-server` on 127.0.0.1:8091
- document optional legacy `arw-svc` snippets that keep port 8090 for the bridge UI
- expand security notes to call out protecting the triad routes and scope `/admin/*` hardening to the legacy bridge

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68ca16ac481083308fab6067bdf64dfa