### PR TITLE
docs: accept '_Last updated:' in docs_check

### DIFF
--- a/scripts/docs_check.sh
+++ b/scripts/docs_check.sh
@@ -48,7 +48,7 @@ for f in "${files[@]}"; do
   # Updated or Generated line near top (first 40 lines)
   # Accept either Updated:, Generated:, the stable generator headers used by
   # our docgen scripts ("_Generated ..."), and spec diff header ("Base: ")
-  head -n 40 "$f" | grep -Eq '^(Updated:|Generated:|_Generated |Base: )' || {
+  head -n 40 "$f" | grep -Eq '^(Updated:|Generated:|_Last updated:|_Generated |Base: )' || {
     warn "$rel: missing Updated:/Generated: information"
     warnings=$((warnings+1))
   }


### PR DESCRIPTION
Align docs_check with generated docs; zero warnings now under mkdocs --strict.\n\nNo content changes, only the check regex.