### PR TITLE
Update OpenAPI license metadata

### DIFF
--- a/docs/static/openapi.json
+++ b/docs/static/openapi.json
@@ -4,7 +4,8 @@
     "title": "Agent Hub (ARW) Service API",
     "description": "Your private AI control room that can scale and share when you choose.\n\nIn plain terms: Agent Hub (ARW) lets you run your own team of AI “helpers” on your computer to research, plan, write, and build—while you stay in charge. It is local‑first and privacy‑first by default, with the option to securely pool computing power with trusted peers when a project needs more muscle.\n",
     "license": {
-      "name": ""
+      "name": "MIT OR Apache-2.0",
+      "url": "https://github.com/t3hw00t/ARW#licensing"
     },
     "version": "0.1.0"
   },

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -8,7 +8,8 @@ info:
     \ to securely pool computing power with trusted peers when a project needs more\
     \ muscle.\n"
   license:
-    name: ''
+    name: MIT OR Apache-2.0
+    url: https://github.com/t3hw00t/ARW#licensing
   version: 0.1.0
 paths:
   /about:


### PR DESCRIPTION
## Summary
- set the OpenAPI spec license name to the MIT/Apache-2.0 dual-license string and add a link to the repository’s licensing docs
- regenerate docs/static/openapi.json so the published schema inherits the updated license metadata

## Testing
- python3 scripts/generate_openapi_json.py

------
https://chatgpt.com/codex/tasks/task_e_68cb565afec083308d6e4bca3964c867